### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners
+/.github/ @jmanning-stackav @rhsu-stackav

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owners
+* @jmanning-stackav @rhsu-stackav


### PR DESCRIPTION
This PR adds @jmanning-stackav and @rhsu-stackav as the default CODEOWNERS of the entire Conch repo and the CODEOWNERS file itself. [Docs for reference](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).