### PR TITLE
Update interfaces for vLLM==0.8.5

### DIFF
--- a/conch/ops/vllm/reshape_and_cache.py
+++ b/conch/ops/vllm/reshape_and_cache.py
@@ -95,9 +95,9 @@ def reshape_and_cache(
     key_cache: torch.Tensor,
     value_cache: torch.Tensor,
     slot_mapping: torch.Tensor,
-    kv_cache_dtype: str = "auto",
-    k_scale: float = 1.0,
-    v_scale: float = 1.0,
+    kv_cache_dtype: str,
+    k_scale: torch.Tensor,
+    v_scale: torch.Tensor,
 ) -> None:
     """Reshape key/value vectors and add them to the cache.
 

--- a/conch/reference/activation/silu_and_mul.py
+++ b/conch/reference/activation/silu_and_mul.py
@@ -17,15 +17,10 @@ def _silu_and_mul_pytorch_ref(x: torch.Tensor) -> torch.Tensor:
 
 def _silu_and_mul_vllm_ref(x: torch.Tensor) -> torch.Tensor:
     """vLLM reference silu and mul implementation."""
-    from vllm._custom_ops import silu_and_mul as silu_and_mul_cuda
+    from vllm.model_executor.layers.activation import SiluAndMul
 
-    d = x.shape[-1] // 2
-    output_shape = x.shape[:-1] + (d,)
-    out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-
-    silu_and_mul_cuda(out, x)
-
-    return out
+    silu_layer = SiluAndMul()  # type: ignore[no-untyped-call]
+    return silu_layer.forward_cuda(x)
 
 
 def silu_and_mul(x: torch.Tensor) -> torch.Tensor:

--- a/conch/third_party/vllm/utils.py
+++ b/conch/third_party/vllm/utils.py
@@ -137,12 +137,12 @@ def reshape_vllm_kvcache(
         value_cache_vllm: vLLM value cache, shape: (num_cache_blocks, num_kv_heads, head_size, cache_block_size).
 
     Returns:
-        Reshaped key and value caches as (num_cache_blocks, num_kv_heads * cache_block_size * head_size).
+        Reshaped key and value caches as (num_cache_blocks, num_kv_heads, cache_block_size, head_size).
     """
     num_cache_blocks, num_kv_heads, head_size, cache_block_size = value_cache_vllm.shape
 
-    k = key_cache_vllm.permute(0, 1, 3, 2, 4).reshape(num_cache_blocks, num_kv_heads * cache_block_size * head_size)
-    v = value_cache_vllm.permute(0, 1, 3, 2).reshape(num_cache_blocks, num_kv_heads * cache_block_size * head_size)
+    k = key_cache_vllm.permute(0, 1, 3, 2, 4).contiguous().reshape(num_cache_blocks, num_kv_heads, cache_block_size, head_size)
+    v = value_cache_vllm.permute(0, 1, 3, 2).contiguous().reshape(num_cache_blocks, num_kv_heads, cache_block_size, head_size)
 
     return k, v
 

--- a/docs/getting_started/developer_environment.md
+++ b/docs/getting_started/developer_environment.md
@@ -82,6 +82,6 @@ Most unit tests/benchmarks allow comparison to CUDA implementations of operation
 In order to use them, you can install vLLM (`pip install vllm`) and set the environment variable `CONCH_ENABLE_VLLM=1`.
 
 ```bash
-pip install vllm==0.6.4
+pip install vllm==0.8.5
 CONCH_ENABLE_VLLM=1 python benchmarks/paged_attention_benchmark.py
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ use_parentheses = true
 explicit_package_bases = true
 strict = true
 exclude = [
+  "build/",
   "conch/third_party/",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,14 @@ _REQUIREMENTS: Final = [
 ]
 
 _DEFAULT_PLATFORM_REQUIREMENTS: Final = [
-    "torch>=2.5.1",
+    "torch>=2.6.0",
     "triton>=3.1.0",
 ]
 
 # --extra-index-url https://download.pytorch.org/whl/rocm6.2
 _ROCM_PLATFORM_REQUIREMENTS: Final = [
-    "amdsmi==6.2.2.post0",
-    "torch==2.5.1+rocm6.2",
+    "amdsmi==6.2.4",
+    "torch==2.6.0+rocm6.2.4",
     "pytorch-triton-rocm>=3.1.0",
 ]
 

--- a/tools/create_benchmark_results_table.py
+++ b/tools/create_benchmark_results_table.py
@@ -56,6 +56,7 @@ def main(results_directory: Path, use_cached_results: bool) -> None:
     os.environ["CONCH_BENCH_ENABLE_ALL_REF"] = "1"
     os.environ["CONCH_ENABLE_BNB"] = "1"
     os.environ["CONCH_ENABLE_VLLM"] = "1"
+    os.environ["VLLM_CONFIGURE_LOGGING"] = "0"
 
     # Create directory for output if it doesn't exist already
     results_directory.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
### Description

Updates interfaces to conch functions to match the latest version of vLLM (`0.8.5`).
This requires updating to `triton==3.2.0` and `torch==2.6.0`. 

### Testing

Please select all that apply.

- [x] Existing unit tests
- [ ] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

**A10**
```
12617 passed, 7458 skipped in 430.78s (0:07:10)
```

**A10 benchmarks**
| Operation | CUDA Runtime | Triton Runtime | Triton Speedup |
| --- | --- | --- | --- |
| GeLU, Tanh, and Mul | 3.137 ms | 2.851 ms | 1.10 |
| SiLU and Mul | 0.560 ms | 0.209 ms | 2.68 |
| Paged Attention | 0.331 ms | 0.305 ms | 1.09 |
| Rotary Embedding | 0.579 ms | 0.600 ms | 0.96 |
| RMS Norm (Gemma-style) | 1.698 ms | 0.141 ms | 12.04 |
| RMS Norm (Llama-style) | 0.118 ms | 0.072 ms | 1.64 |
| bitsandbytes: Dequantize | 0.176 ms | 11.058 ms | 0.02 |
| bitsandbytes: Quantize | 0.682 ms | 12.801 ms | 0.05 |
| Int8 Static Quantization | 0.167 ms | 0.251 ms | 0.67 |
| Scaled GEMM [Int8 x BF16] | 2.143 ms | 4.439 ms | 0.48 |
| vLLM: Copy Blocks | 8.558 ms | 9.930 ms | 0.86 |
| vLLM: Reshape and Cache | 0.245 ms | 0.148 ms | 1.66 |

**Note**: it does look like there are some performance regressions on H100? We still need to investigate those.

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [ ] AMD GPU
- [ ] Other (please explain)
