### PR TITLE
Add varlen attention

### DIFF
--- a/benchmarks/varlen_attention_benchmark.py
+++ b/benchmarks/varlen_attention_benchmark.py
@@ -1,0 +1,326 @@
+# Copyright (C) 2025 Stack AV Co. - All Rights Reserved.
+
+"""Triton varlen attention vs. FlashAttnVarlen benchmark."""
+
+import sys
+from typing import Final
+
+import click
+import torch
+
+from conch import envs
+from conch.ops.attention.varlen_attention import varlen_attention
+from conch.platforms import current_platform
+from conch.third_party.vllm.utils import create_tensors, seed_everything
+from conch.utils.benchmark import BenchmarkMetadata, benchmark_it
+
+if envs.CONCH_ENABLE_VLLM and current_platform.is_nvidia():
+    from vllm.vllm_flash_attn import flash_attn_varlen_func  # type: ignore[attr-defined, unused-ignore]
+else:
+    flash_attn_varlen_func = None  # type: ignore[assignment]
+
+
+@click.command()
+@click.option(
+    "-h",
+    "--head-dim",
+    required=True,
+    type=int,
+    default=256,
+    help="Head dimension",
+)
+@click.option(
+    "-s",
+    "--seq-len",
+    required=True,
+    type=int,
+    default=1024,
+    help="Sequence length (for k/v)",
+)
+@click.option(
+    "-c",
+    "--cache-block-size",
+    required=True,
+    type=int,
+    default=32,
+    help="Number of KV vectors in each cache block",
+)
+@click.option(
+    "-b",
+    "--batch-size",
+    required=False,
+    type=int,
+    default=10,
+    help="Batch size",
+)
+@click.option(
+    "-h",
+    "--num-query-heads",
+    required=False,
+    type=int,
+    default=8,
+    help="Number of query heads",
+)
+@click.option(
+    "-k",
+    "--num-kv-heads",
+    required=False,
+    type=int,
+    default=4,
+    help="Number of kv heads",
+)
+@click.option(
+    "--causal",
+    required=False,
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Flag for printing results in CSV format",
+)
+@click.option(
+    "--pure-decode",
+    required=False,
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Flag for printing results in CSV format",
+)
+@click.option(
+    "-i",
+    "--num-iterations",
+    required=False,
+    type=int,
+    default=100,
+    help="Number of iterations",
+)
+@click.option(
+    "-w",
+    "--num-warmup-iterations",
+    required=False,
+    type=int,
+    default=10,
+    help="Number of warmup iterations",
+)
+@click.option(
+    "-a",
+    "--absolute-tolerance",
+    required=False,
+    type=float,
+    default=1e-3,
+    help="Absolute tolerance to match with",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    required=False,
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Flag for printing verbose output",
+)
+@click.option(
+    "-g",
+    "--gpu",
+    required=False,
+    type=str,
+    default=current_platform.device,
+    help="Device to run on",
+)
+@click.option(
+    "--csv",
+    required=False,
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Flag for printing results in CSV format",
+)
+def main(
+    head_dim: int,
+    seq_len: int,
+    cache_block_size: int,
+    batch_size: int,
+    num_query_heads: int,
+    num_kv_heads: int,
+    causal: bool,
+    pure_decode: bool,
+    num_iterations: int,
+    num_warmup_iterations: int,
+    absolute_tolerance: float,
+    verbose: bool,
+    gpu: str,
+    csv: bool,
+) -> None:
+    """Benchmark Triton PagedAttention.
+
+    Args:
+        head_dim: Head dimension of input tensors.
+        seq_len: Sequence length of input tensors.
+        cache_block_size: Number of KV vectors in each cache block.
+        batch_size: Batch size of input tensors.
+        num_query_heads: Number of attention query heads.
+        num_kv_heads: Number of attention kv heads.
+        num_iterations: Number of iterations to record benchmark times for each impl.
+        num_warmup_iterations: Number of iterations to "warmup" each impl before recording benchmark times.
+        absolute_tolerance: Absolute tolerance used to check accuracy of PyTorch vs. Triton.
+        verbose: Flag to indicate whether or not to print verbose output.
+        gpu: Which gpu to run on.
+        csv: Flag to indicate whether or not to print results in CSV format.
+    """
+    seed: Final = 0
+    seed_everything(seed)
+
+    device: Final = torch.device(current_platform.device)
+    torch.set_default_device(device)
+
+    scale: Final = float(1.0 / (head_dim**0.5))
+
+    metadata = BenchmarkMetadata(
+        platform=current_platform.name(),
+        params={
+            "head_dim": head_dim,
+            "seq_len": seq_len,
+            "cache_block_size": cache_block_size,
+            "batch_size": batch_size,
+            "num_query_heads": num_query_heads,
+            "num_kv_heads": num_kv_heads,
+            "causal": causal,
+            "pure_decode": pure_decode,
+        },
+    )
+
+    kv_cache_dtype: Final = "auto"
+    dtype: Final = torch.float16
+
+    _, _, _, key_cache_conch, value_cache_conch, block_tables, seq_lens = create_tensors(
+        head_dim,
+        seq_len,
+        cache_block_size,
+        batch_size,
+        num_query_heads,
+        num_kv_heads,
+        kv_cache_dtype,
+        current_platform.device,
+        dtype,
+    )
+
+    starting_item = torch.as_tensor([0], dtype=torch.int32)
+
+    if pure_decode:
+        seqlens_q = torch.ones((batch_size,), dtype=torch.int32)
+
+        cu_seqlens_q = torch.cumsum(seqlens_q, dim=0, dtype=torch.int32)
+        cu_seqlens_q = torch.cat((starting_item, cu_seqlens_q), dim=0)
+
+        cu_seqlens_k = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
+        cu_seqlens_k = torch.cat((starting_item, cu_seqlens_k), dim=0)
+
+        max_seqlen_q = int(torch.max(seqlens_q).item())
+        max_seqlen_k = int(torch.max(seq_lens).item())
+    else:
+        cu_seqlens_q = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
+
+        cu_seqlens_q = torch.cat((starting_item, cu_seqlens_q), dim=0)
+        cu_seqlens_k = cu_seqlens_q.clone()
+
+        max_seqlen_q = int(torch.max(seq_lens).item())
+        max_seqlen_k = int(max_seqlen_q)
+
+    total_num_q = int(cu_seqlens_q[-1].item())
+
+    query = torch.empty((total_num_q, num_query_heads, head_dim), dtype=dtype, device=device)
+    query.uniform_(-scale, scale)
+
+    output_conch = varlen_attention(
+        query=query,
+        key_cache=key_cache_conch,
+        value_cache=value_cache_conch,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        scale=scale,
+        causal=causal,
+    )
+
+    if flash_attn_varlen_func is not None:
+        key_cache_fa = key_cache_conch.permute(0, 2, 1, 3)
+        value_cache_fa = value_cache_conch.permute(0, 2, 1, 3)
+
+        output_vllm = flash_attn_varlen_func(
+            q=query,
+            k=key_cache_fa,
+            v=value_cache_fa,
+            cu_seqlens_q=cu_seqlens_q,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            block_table=block_tables,
+            seqused_k=seq_lens,
+            softmax_scale=scale,
+            causal=causal,
+        )
+
+        if not torch.allclose(output_vllm, output_conch, atol=absolute_tolerance):
+            print(f"WARNING: Reference and Triton results differ! (atol={absolute_tolerance})", file=sys.stderr)
+            print(f"Output max diff: {(output_conch - output_vllm).abs().max().item()}", file=sys.stderr)
+
+            if verbose:
+                print(f"Reference output: {output_vllm}", file=sys.stderr)
+                print(f"Triton output: {output_conch}", file=sys.stderr)
+        else:
+            print(f"Results matched with atol={absolute_tolerance} :)", file=sys.stderr)
+
+        baseline_result = benchmark_it(
+            lambda: flash_attn_varlen_func(
+                q=query,
+                k=key_cache_fa,
+                v=value_cache_fa,
+                cu_seqlens_q=cu_seqlens_q,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
+                block_table=block_tables,
+                seqused_k=seq_lens,
+                softmax_scale=scale,
+                causal=causal,
+            ),
+            tag="Baseline",
+            metadata=metadata,
+            num_iterations=num_iterations,
+            num_warmup_iterations=num_warmup_iterations,
+            device=query.device,
+        )
+    else:
+        print("Skipping checking vs. reference vLLM implementation...", file=sys.stderr)
+        baseline_result = None
+
+    triton_result = benchmark_it(
+        lambda: varlen_attention(
+            query=query,
+            key_cache=key_cache_conch,
+            value_cache=value_cache_conch,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=max_seqlen_q,
+            max_seqlen_k=max_seqlen_k,
+            scale=scale,
+            causal=causal,
+        ),
+        tag="Triton",
+        metadata=metadata,
+        num_iterations=num_iterations,
+        num_warmup_iterations=num_warmup_iterations,
+        device=query.device,
+    )
+
+    # Print results
+    triton_result.print_parameters(csv=csv)
+    triton_result.print_results(csv=csv)
+    if baseline_result is not None:
+        baseline_result.print_results(csv=csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/conch/kernels/attention/varlen_attention.py
+++ b/conch/kernels/attention/varlen_attention.py
@@ -1,0 +1,806 @@
+# Copyright (C) 2025 Stack AV Co. - All Rights Reserved.
+
+"""Triton implementation of Flash Attention w/ Paged KV Cache + FlashDecoding.
+
+Compatible with A10, H100, AMD MI300X.
+"""
+
+from typing import Final
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra import libdevice  # type: ignore[attr-defined]
+
+from conch.platforms import current_platform
+
+# The maximum number of stage 1 kernels to launch to split processing of the sequence
+MAX_NUM_KV_SPLITS: Final = 4
+
+# Note: adding `bool` or `str` type annotations to these load/store helper functions doesn't work
+
+
+@triton.jit  # type: ignore[misc]
+def _load_2d_block_ptr(  # type: ignore[no-untyped-def]
+    data_ptr: tl.tensor,
+    mask_first_dim,
+    mask_second_dim,
+    padding_option,
+) -> tl.tensor:
+    """Load a 2D tensor with custom strides and offsets."""
+    if mask_first_dim and mask_second_dim:
+        # Load with boundary check on both dimensions
+        data = tl.load(data_ptr, boundary_check=(0, 1), padding_option=padding_option)
+    elif mask_first_dim:
+        # Load with boundary check on first dimension only
+        data = tl.load(data_ptr, boundary_check=(0,), padding_option=padding_option)
+    elif mask_second_dim:
+        # Load with boundary check on second dimension only
+        data = tl.load(data_ptr, boundary_check=(1,), padding_option=padding_option)
+    else:
+        # Load without boundary check
+        data = tl.load(data_ptr)
+
+    return data
+
+
+@triton.jit  # type: ignore[misc]
+def _load(  # type: ignore[no-untyped-def]
+    data_ptr: tl.tensor,
+    use_mask,
+    mask: tl.tensor,
+    other,
+) -> tl.tensor:
+    """Load a 1D tensor with custom strides and offsets."""
+    if use_mask:
+        # Load with mask
+        data = tl.load(data_ptr, mask=mask, other=other)
+    else:
+        # Load without mask
+        data = tl.load(data_ptr)
+
+    return data
+
+
+@triton.jit  # type: ignore[misc]
+def _store(  # type: ignore[no-untyped-def]
+    data_ptr: tl.tensor,
+    value: tl.tensor,
+    use_mask,
+    mask: tl.tensor,
+) -> None:
+    """Store a 1D tensor with custom strides and offsets."""
+    if use_mask:
+        # Store with mask
+        tl.store(data_ptr, value, mask=mask)
+    else:
+        # Store without mask
+        tl.store(data_ptr, value)
+
+
+@triton.jit  # type: ignore[misc]
+def _varlen_attention_compute_splits_kernel(  # noqa: PLR0913, PLR0915
+    # Pointers to tensors
+    output_scratchpad_ptr: tl.tensor,  # (total_num_q, MAX_NUM_KV_SPLITS, num_query_heads, head_size)
+    lse_scratchpad_ptr: tl.tensor,  # (total_num_q, MAX_NUM_KV_SPLITS, num_query_heads)
+    query_ptr: tl.tensor,  # (total_num_q, num_query_heads, head_size)
+    key_cache_ptr: tl.tensor,  # (num_cache_blocks, num_kv_heads, cache_block_size, head_size)
+    value_cache_ptr: tl.tensor,  # (num_cache_blocks, num_kv_heads, cache_block_size, head_size)
+    block_tables_ptr: tl.tensor,  # (batch_size, max_num_blocks_per_sequence)
+    seq_lens_ptr: tl.tensor,  # (batch_size, )
+    cu_seqlens_q_ptr: tl.tensor,  # (batch_size + 1, )
+    cu_seqlens_k_ptr: tl.tensor,  # (batch_size + 1, )
+    # Scalar arguments
+    scale: float,
+    num_query_splits: int,
+    num_cache_blocks_per_split: int,
+    softcap: float,
+    k_scale: float,
+    v_scale: float,
+    # Sizes of tensors above
+    head_size: int,  # output.shape[3]
+    query_group_size: int,  # num_query_heads // num_kv_heads
+    # Strides for tensors above
+    output_scratchpad_batch_stride: int,  # output_scratchpad.stride(0)
+    output_scratchpad_kv_split_stride: int,  # output_scratchpad.stride(1)
+    output_scratchpad_head_stride: int,  # output_scratchpad.stride(2)
+    lse_scratchpad_batch_stride: int,  # lse_scratchpad.stride(0)
+    lse_scratchpad_kv_split_stride: int,  # lse_scratchpad.stride(1)
+    query_batch_stride: int,  # query.stride(0)
+    query_head_stride: int,  # query.stride(1)
+    kv_page_stride: int,  # key_cache.stride(0), same for key and value
+    kv_head_stride: int,  # key_cache.stride(1), same for key and value
+    kv_cache_block_stride: int,  # key_cache.stride(2), same for key and value
+    kv_head_element_stride: int,  # key_cache.stride(3), same for key and value
+    block_tables_batch_stride: int,  # block_tables.stride(0)
+    # Constexprs
+    cxpr_query_chunk_size: tl.constexpr,
+    cxpr_cache_block_size: tl.constexpr,
+    cxpr_head_size_padded: tl.constexpr,
+    cxpr_is_softcap: tl.constexpr,
+    cxpr_apply_fp8_scaling: tl.constexpr,
+    cxpr_is_rocm: tl.constexpr,
+    cxpr_is_causal: tl.constexpr,
+) -> None:
+    """Varlen Attention kernel: compute attention for a split block.
+
+    Args:
+        output_scratchpad_ptr: Pointer to tensor as scratchpad for output of each cache block, shape: (total_num_q, MAX_NUM_KV_SPLITS, num_query_heads, head_size).
+        lse_scratchpad_ptr: Pointer to tensor as scratchpad for log-sum-exp of each cache block, shape: (total_num_q, MAX_NUM_KV_SPLITS, num_query_heads).
+        query_ptr: Pointer to tensor storing the query, shape: (total_num_q, num_query_heads, head_size).
+        key_cache_ptr: Tensor with cached K values, shape: (num_blocks, num_kv_heads, cache_block_size, head_size).
+        value_cache_ptr: Tensor with cached V values, shape: (num_blocks, num_kv_heads, cache_block_size, head_size).
+        block_tables_ptr: Pointer to tensor storing the mapping from batch to cache blocks, shape: (batch_size, max_num_blocks_per_sequence).
+        seq_lens_ptr: Pointer to tensor holding the current sequence length for each sequence in the batch, shape: (batch_size, ).
+        cu_seqlens_q_ptr: Pointer to tensor holding the cumulative sequence lengths for each sequence in the batch, shape: (batch_size, ).
+        cu_seqlens_k_ptr: Pointer to tensor holding the cumulative sequence lengths for each sequence in the batch, shape: (batch_size, ).
+        scale: Scaling factor, 1/sqrt(head_size).
+        num_query_splits: The number of "splits" we split each query into.
+        num_cache_blocks_per_split: The maximum number of cache blocks in each split (max num each kernel will process).
+        softcap: Logits softcap to apply.
+        k_scale: Fp8 scaling factor for k.
+        v_scale: Fp8 scaling factor for v.
+        head_size: Actual head dim, not padded to power-of-two.
+        query_group_size: The number of query heads to group together, not padded to power-of-two.
+        output_scratchpad_batch_stride: Stride of the output scratchpad tensor in the 0th dimension.
+        output_scratchpad_kv_split_stride: Stride of the output scratchpad tensor in the 1st dimension.
+        output_scratchpad_head_stride: Stride of the output scratchpad tensor in the 2nd dimension.
+        lse_scratchpad_batch_stride: Stride of the log-sum-exp scratchpad tensor in the 0th dimension.
+        lse_scratchpad_kv_split_stride: Stride of the log-sum-exp scratchpad tensor in the 1st dimension.
+        query_batch_stride: Stride of the query tensor in the 0th dimension.
+        query_head_stride: Stride of the query tensor in the 1st dimension.
+        kv_page_stride: Stride of the k/v tensors in the 0th dimension.
+        kv_head_stride: Stride of the k/v tensors in the 1st dimension.
+        kv_cache_block_stride: Stride of the k/v tensors in the 2nd dimension.
+        kv_head_element_stride: Stride of the k/v tensors in the 3rd dimension.
+        block_tables_batch_stride: Stride of the block table tensor in the 0th dimension.
+        cxpr_query_chunk_size: The size of the query chunks (must be power of two!).
+        cxpr_cache_block_size: The size of the cache blocks (must be power of two!).
+        cxpr_head_size_padded: The head size of the attention layer padded to the next power of two.
+        cxpr_is_softcap: Whether or not logits softcapping will be applied.
+        cxpr_apply_fp8_scaling: Whether or not to apply FP8 scaling.
+        cxpr_is_rocm: Whether or not we're on AMD.
+        cxpr_is_causal: Whether or not to apply causal masking.
+    """
+    # What batch is this program processing?
+    batch_index = tl.program_id(0)
+
+    # What "split" of the overall data (between 1 and M for query chunks and between 1 and N for KV cache blocks) is this program processing?
+    split_index = tl.program_id(1)
+    total_num_splits = tl.num_programs(1)
+
+    query_split_index = split_index // tl.cdiv(total_num_splits, num_query_splits)
+    kv_split_index = split_index % tl.cdiv(total_num_splits, num_query_splits)
+
+    # What query head is this program processing?
+    query_head_index = tl.program_id(2)
+
+    # Get type that we should be using for accumulating results/intermediate calculations
+    dtype = output_scratchpad_ptr.dtype.element_ty
+
+    # Load scalar current_sequence_length for the current sequence in the batch
+    # This is the KV sequence length, not the Q sequence length
+    current_sequence_length = tl.load(seq_lens_ptr + batch_index)
+
+    # The length of the current sequence will tell us how many cache blocks we need to read
+    current_seq_num_cache_blocks = tl.cdiv(current_sequence_length, cxpr_cache_block_size)
+
+    # What is the first cache block index in the set for this split
+    starting_cache_block_index = kv_split_index * num_cache_blocks_per_split
+
+    # We launch the same number of splits for all sequences in the batch, so different kernel launches will have different numbers of cache blocks
+    # to process. So we may have a case where one sequence in a batch has sufficiently fewer cache blocks to process such that a kernel doesn't have
+    # any blocks to process.
+    if starting_cache_block_index >= current_seq_num_cache_blocks:
+        return
+
+    # Compute length of current sequence's query
+    this_query_start = tl.load(cu_seqlens_q_ptr + batch_index)
+    this_query_end = tl.load(cu_seqlens_q_ptr + batch_index + 1)
+    this_query_length = this_query_end - this_query_start
+
+    # If the query length is just one token, then we have a decode case
+    is_pure_decode = this_query_length == 1
+
+    # Offset for how many tokens in query correspond to previous splits for this sequence
+    this_query_split_offset = query_split_index * cxpr_query_chunk_size
+
+    # Similar to above, we launch the same number of splits for all sequences in the batch, so different kernel launches will have different
+    # numbers of query tokens to process. If we've already processed all of the query tokens for this sequence, we can skip this kernel.
+    if this_query_split_offset > this_query_length:
+        return
+
+    if cxpr_is_causal and not is_pure_decode:
+        beginning_seqlen_k = starting_cache_block_index * cxpr_cache_block_size
+        if (this_query_split_offset + cxpr_query_chunk_size) < beginning_seqlen_k:
+            return
+
+    # Offsets for each query vector in the group
+    query_split_offsets = this_query_split_offset + tl.arange(0, cxpr_query_chunk_size)
+    # Need to mask out if any of these tokens are out of bounds
+    query_split_mask = query_split_offsets < this_query_length
+
+    # How many previous sequences are there before this one?
+    num_previous_sequences = tl.load(cu_seqlens_q_ptr + batch_index)
+
+    # Offsets to each element of the padded-to-next-power-of-two head size
+    head_offsets = tl.arange(0, cxpr_head_size_padded)
+    # Mask to only read valid indices of the actual head size
+    head_mask = head_offsets < head_size
+
+    # Offsets for the queries in this block
+    query_offsets = (
+        # Offset for the number of tokens for previous sequences
+        num_previous_sequences * query_batch_stride
+        +
+        # Offsets for each of the sequences in this split
+        query_split_offsets[:, None] * query_batch_stride
+        +
+        # Offset for the query head this program is processing
+        query_head_index * query_head_stride
+        +
+        # Offset for each element of the head
+        head_offsets[None, :]
+    )
+
+    # Mask out query elements that are just for padding
+    query_mask = query_split_mask[:, None] & head_mask[None, :]
+
+    # Determine whether or not we need masking for different dimensions
+    needs_query_split_mask = (this_query_split_offset + cxpr_query_chunk_size) > this_query_length
+    needs_head_mask = head_size != cxpr_head_size_padded
+    needs_query_mask = needs_query_split_mask or needs_head_mask
+
+    # Load queries
+    query = _load(query_ptr + query_offsets, use_mask=needs_query_mask, mask=query_mask, other=0.0)
+
+    # Index/offset for the current kv_head in the key_cache and value_cache
+    kv_head_index = query_head_index // query_group_size
+    kv_head_index_offset = kv_head_index * kv_head_stride
+
+    # Pointer arithmetic to get to the entry in the block_tables for the current batch_index
+    current_block_table_offset = batch_index * block_tables_batch_stride
+    current_block_table_ptr = block_tables_ptr + current_block_table_offset
+
+    # Scratchpad for output from this group of cache blocks
+    output = tl.zeros([cxpr_query_chunk_size, cxpr_head_size_padded], dtype=dtype)
+    # Keep running max of softmax numerator (scale * Q * K)
+    m_i = tl.full([cxpr_query_chunk_size], -float("inf"), dtype=dtype)
+    # Keep running denominator of softmax
+    l_i = tl.full([cxpr_query_chunk_size], 0.0, dtype=dtype)
+
+    # Iterate through the cache blocks that this kernel is assigned to
+    for relative_cache_block_index in range(num_cache_blocks_per_split):
+        # Get the actual index of the cache block
+        cache_block_index = starting_cache_block_index + relative_cache_block_index
+
+        # If our cache block index is greater than or equal to the number of active cache blocks for the current sequence,
+        # skip this block
+        # Note: `break` / `continue` is unsupported in Triton, so we have to nest here
+        if cache_block_index < current_seq_num_cache_blocks:
+            # Calculate number of entries in this cache block (will be a value between 1 and cache_block_size)
+            num_entries_in_cache_block = min(
+                current_sequence_length - (cache_block_index * cxpr_cache_block_size), cxpr_cache_block_size
+            )
+
+            needs_cache_block_mask = num_entries_in_cache_block != cxpr_cache_block_size
+            needs_qk_mask = needs_query_split_mask or needs_cache_block_mask
+
+            # Offset from the block_table row for the current batch by the number of cache blocks
+            current_cache_block_number_ptr = current_block_table_ptr + cache_block_index
+            physical_cache_block_number = tl.load(current_cache_block_number_ptr)
+
+            # Calculate address of current cache block
+            kv_cache_block_index_offset = physical_cache_block_number * kv_page_stride
+
+            # Load the key block as (cxpr_head_size_padded, cache_block_size)
+            # Note: we're loading it transposed here
+            key_block_ptr = tl.make_block_ptr(
+                key_cache_ptr + kv_cache_block_index_offset + kv_head_index_offset,
+                shape=(head_size, num_entries_in_cache_block),
+                strides=(kv_head_element_stride, kv_cache_block_stride),
+                offsets=(0, 0),
+                block_shape=(cxpr_head_size_padded, cxpr_cache_block_size),
+                order=(1, 0),
+            )
+
+            key_block = _load_2d_block_ptr(
+                key_block_ptr,
+                mask_first_dim=needs_head_mask,
+                mask_second_dim=needs_cache_block_mask,
+                padding_option="zero",
+            )
+
+            if cxpr_apply_fp8_scaling:
+                # Dequantize (multiply by scale factor)
+                fp8_dtype = tl.float8e4b8 if cxpr_is_rocm else tl.float8e4nv
+                key_block = (key_block.to(fp8_dtype, bitcast=True) * k_scale).to(dtype)
+
+            # Multiply query vector by key matrix for this cache block (and apply scaling factor)
+            # query.shape -> (query_chunk_size, head_size)
+            # key_block.shape -> (head_size, cache_block_size)
+            # qk.shape -> (query_chunk_size, cache_block_size)
+            qk = (scale * tl.dot(query, key_block)).to(dtype)
+
+            # Need to mask out any elements that represent unused cache block entries or padding elements
+            cache_block_mask = tl.arange(0, cxpr_cache_block_size) < num_entries_in_cache_block
+            qk_mask = query_split_mask[:, None] & cache_block_mask[None, :]
+
+            needs_causal_mask = cxpr_is_causal and not is_pure_decode
+
+            if needs_causal_mask:
+                # Causal mask
+                effective_seqlen_k_offsets = cache_block_index * cxpr_cache_block_size + tl.arange(
+                    0, cxpr_cache_block_size
+                )
+                causal_mask = query_split_offsets[:, None] >= effective_seqlen_k_offsets[None, :]
+                qk_mask = qk_mask & causal_mask
+
+            if needs_qk_mask or needs_causal_mask:
+                # Set masked out elements to -inf
+                qk = tl.where(qk_mask, qk, -float("inf")).to(dtype)
+
+            # Handle softcapping
+            if cxpr_is_softcap:
+                # tanh can only accept fp32 or fp64 arguments
+                qk = (softcap * libdevice.tanh((qk / softcap).to(tl.float32))).to(dtype)
+
+            # Reduce maximum between running max and the max of (scale * Q * K) for this cache block
+            m_ij = tl.maximum(m_i, tl.max(qk, axis=1)).to(dtype)
+
+            # Calculate numerator of softmax for this cache block
+            p = tl.exp((qk - m_ij[:, None]).to(tl.float32)).to(dtype)
+            # Need to mask out any elements that represent unused cache block entries or padding elements
+            p = tl.where(qk_mask, p, 0.0).to(dtype)
+
+            # Calculate sum of softmax numerator for this cache block
+            l_ij = tl.sum(p, axis=1).to(dtype)
+
+            # Calculate correction factor for this cache block
+            alpha = tl.exp((m_i - m_ij).to(tl.float32)).to(dtype)
+
+            # Apply scaling factor to running output
+            output *= alpha[:, None]
+
+            # Load the value block as (cache_block_size, cxpr_head_size_padded)
+            value_block_ptr = tl.make_block_ptr(
+                value_cache_ptr + kv_cache_block_index_offset + kv_head_index_offset,
+                shape=(num_entries_in_cache_block, head_size),
+                strides=(kv_cache_block_stride, kv_head_element_stride),
+                offsets=(0, 0),
+                block_shape=(cxpr_cache_block_size, cxpr_head_size_padded),
+                order=(0, 1),
+            )
+
+            value_block = _load_2d_block_ptr(
+                value_block_ptr,
+                mask_first_dim=needs_cache_block_mask,
+                mask_second_dim=needs_head_mask,
+                padding_option="zero",
+            )
+
+            if cxpr_apply_fp8_scaling:
+                # Dequantize (multiply by scale factor)
+                fp8_dtype = tl.float8e4b8 if cxpr_is_rocm else tl.float8e4nv
+                value_block = (value_block.to(fp8_dtype, bitcast=True) * v_scale).to(dtype)
+
+            # Multiply softmax probabilities by value matrix for this cache block
+            # p.shape -> (query_chunk_size, cache_block_size)
+            # value_block.shape -> (cache_block_size, head_size)
+            # output.shape -> (query_chunk_size, head_size)
+            output += tl.dot(p, value_block).to(dtype)
+
+            # Update running max
+            m_i = m_ij
+            # Update running denominator
+            l_i = l_i * alpha + l_ij
+
+    # Apply correction for denominator of these cache blocks
+    output /= l_i[:, None]
+
+    # Calculate offsets to store the output for this query split/query head
+    # 2D block of shape (query_chunk_size, head_size_padded)
+    output_scratch_offsets = (
+        num_previous_sequences * output_scratchpad_batch_stride
+        + query_split_offsets[:, None] * output_scratchpad_batch_stride
+        + kv_split_index * output_scratchpad_kv_split_stride
+        + query_head_index * output_scratchpad_head_stride
+        + head_offsets[None, :]
+    )
+
+    # Store output scratchpad results
+    _store(
+        output_scratchpad_ptr + output_scratch_offsets,
+        output,
+        use_mask=needs_query_mask,
+        mask=query_mask,
+    )
+
+    # Calculate scratchpad log(sum(exp))
+    # Note: log() only accepts fp32/fp64 arguments
+    lse = m_i + tl.log(l_i.to(tl.float32)).to(dtype)
+
+    # Calculate offsets to store log-sum-exp for this split/head
+    # 1D block of shape (query_chunk_size,)
+    lse_scratch_offsets = (
+        num_previous_sequences * lse_scratchpad_batch_stride
+        + query_split_offsets * lse_scratchpad_batch_stride
+        + kv_split_index * lse_scratchpad_kv_split_stride
+        + query_head_index
+    )
+
+    # Store lse scratchpad results
+    _store(
+        lse_scratchpad_ptr + lse_scratch_offsets,
+        lse,
+        use_mask=needs_query_split_mask,
+        mask=query_split_mask,
+    )
+
+
+@triton.jit  # type: ignore[misc]
+def _varlen_attention_reduce_splits_kernel(  # noqa: PLR0913
+    # Pointers to tensors
+    output_ptr: tl.tensor,  # (total_num_q, num_query_heads, head_size)
+    output_scratchpad_ptr: tl.tensor,  # (total_num_q, MAX_NUM_KV_SPLITS, num_query_heads, head_size)
+    lse_scratchpad_ptr: tl.tensor,  # (total_num_q, MAX_NUM_KV_SPLITS, num_query_heads)
+    seq_lens_ptr: tl.tensor,  # (batch_size, )
+    cu_seqlens_q_ptr: tl.tensor,  # (batch_size + 1, )
+    # Scalars
+    num_cache_blocks_per_split: int,
+    # Sizes of tensors above
+    head_size: int,  # output.shape[2]
+    # Strides for tensors above
+    output_batch_stride: int,  # output.stride(0)
+    output_head_stride: int,  # output.stride(1)
+    output_scratchpad_batch_stride: int,  # output_scratchpad.stride(0)
+    output_scratchpad_kv_split_stride: int,  # output_scratchpad.stride(1)
+    output_scratchpad_head_stride: int,  # output_scratchpad.stride(2)
+    lse_scratchpad_batch_stride: int,  # lse_scratchpad.stride(0)
+    lse_scratchpad_kv_split_stride: int,  # lse_scratchpad.stride(1)
+    # Constexprs
+    cxpr_query_chunk_size: tl.constexpr,
+    cxpr_cache_block_size: tl.constexpr,
+    cxpr_head_size_padded: tl.constexpr,
+    cxpr_is_causal: tl.constexpr,
+) -> None:
+    """Varlen Attention kernel: reduce results across all splits.
+
+    Args:
+        output_ptr: Pointer to tensor for final output, shape: (total_num_q, num_query_heads, head_size).
+        output_scratchpad_ptr: Pointer to tensor as scratchpad for output of each cache block, shape: (total_num_q, MAX_NUM_KV_SPLITS, num_query_heads, head_size).
+        lse_scratchpad_ptr: Pointer to tensor as scratchpad for log-sum-exp of each cache block, shape: (total_num_q, MAX_NUM_KV_SPLITS, num_query_heads).
+        seq_lens_ptr: Pointer to tensor holding the current sequence length for each sequence in the batch, shape: (batch_size, ).
+        num_cache_blocks_per_split: The maximum number of cache blocks each split will process.
+        head_size: Actual head dim, not padded to power-of-two.
+        output_batch_stride: Stride of the output tensor in the 0th dimension.
+        output_head_stride: Stride of the output tensor in the 1st dimension.
+        output_scratchpad_batch_stride: Stride of the output scratchpad tensor in the 0th dimension.
+        output_scratchpad_kv_split_stride: Stride of the output scratchpad tensor in the 1st dimension.
+        output_scratchpad_head_stride: Stride of the output scratchpad tensor in the 2nd dimension.
+        lse_scratchpad_batch_stride: Stride of the log-sum-exp scratchpad tensor in the 0th dimension.
+        lse_scratchpad_kv_split_stride: Stride of the log-sum-exp scratchpad tensor in the 1st dimension.
+        cxpr_cache_block_size: The size of the cache blocks (must be power of two!), as constexpr so that we can use for reshaping tensors.
+        cxpr_head_size_padded: The head size of the attention layer padded to the next power of two.
+    """
+    # What batch is this program processing?
+    batch_index = tl.program_id(0)
+    # What split of the overall query (between 1 and M query chunks) is this program processing?
+    query_split_index = tl.program_id(1)
+    # What query head is this program processing?
+    query_head_index = tl.program_id(2)
+
+    # Get type that we should be using for accumulating results/intermediate calculations
+    dtype = output_ptr.dtype.element_ty
+
+    # Compute length of current sequence's query
+    this_query_start = tl.load(cu_seqlens_q_ptr + batch_index)
+    this_query_end = tl.load(cu_seqlens_q_ptr + batch_index + 1)
+    this_query_length = this_query_end - this_query_start
+
+    is_pure_decode = this_query_length == 1
+
+    # Offset for how many tokens in query correspond to previous splits for this sequence
+    this_query_split_offset = query_split_index * cxpr_query_chunk_size
+
+    # Similar to above, we launch the same number of splits for all sequences in the batch, so different kernel launches will have different
+    # numbers of query tokens to process. If we've already processed all of the query tokens for this sequence, we can skip this kernel.
+    if this_query_split_offset > this_query_length:
+        return
+
+    # Accumulator for the output of this batch/head
+    output = tl.zeros([cxpr_query_chunk_size, cxpr_head_size_padded], dtype=dtype)
+    # Running max of block lse
+    m_i = tl.full([cxpr_query_chunk_size], -float("inf"), dtype=dtype)
+    # Running final scale factor
+    l_i = tl.full([cxpr_query_chunk_size], 0.0, dtype=dtype)
+
+    # Load scalar current_sequence_length for the current batch
+    current_sequence_length = tl.load(seq_lens_ptr + batch_index)
+
+    # The length of the current sequence will tell us how many cache blocks we need to read
+    current_seq_num_cache_blocks = tl.cdiv(current_sequence_length, cxpr_cache_block_size)
+
+    # Offset for how many tokens in query correspond to other sequences
+    num_previous_sequences = tl.load(cu_seqlens_q_ptr + batch_index)
+
+    # Offsets for each query vector in the group
+    query_split_offsets = this_query_split_offset + tl.arange(0, cxpr_query_chunk_size)
+    # Need to mask out if any of these tokens are out of bounds
+    query_split_mask = query_split_offsets < this_query_length
+
+    # Offsets to each element of the padded-to-next-power-of-two head size
+    head_offsets = tl.arange(0, cxpr_head_size_padded)
+    # Mask to only read valid indices of the actual head size
+    head_mask = head_offsets < head_size
+
+    query_mask = query_split_mask[:, None] & head_mask[None, :]
+
+    needs_query_split_mask = (this_query_split_offset + cxpr_query_chunk_size) > this_query_length
+    needs_head_mask = head_size != cxpr_head_size_padded
+    needs_query_mask = needs_query_split_mask or needs_head_mask
+
+    num_kv_splits_this_seq = tl.cdiv(current_seq_num_cache_blocks, num_cache_blocks_per_split)
+
+    # Iterate through every cache block for the current sequence
+    for kv_split_index in range(num_kv_splits_this_seq):
+        effective_seqlen_k = kv_split_index * num_cache_blocks_per_split * cxpr_cache_block_size
+        if ((effective_seqlen_k <= this_query_split_offset) or not cxpr_is_causal) or is_pure_decode:
+            # Calculate offsets to load the scratch for this head/batch/split
+            # 2D block of shape (query_group_size_padded, head_size_padded)
+            output_scratchpad_offsets = (
+                num_previous_sequences * output_scratchpad_batch_stride
+                + query_split_offsets[:, None] * output_scratchpad_batch_stride
+                + kv_split_index * output_scratchpad_kv_split_stride
+                + query_head_index * output_scratchpad_head_stride
+                + head_offsets[None, :]
+            )
+
+            # Load output for this cache block, shape -> (cxpr_query_chunk_size, cxpr_head_size_padded)
+            block_output = _load(
+                output_scratchpad_ptr + output_scratchpad_offsets,
+                use_mask=needs_query_mask,
+                mask=query_mask,
+                other=0.0,
+            )
+
+            # Calculate offsets to load log-sum-exp for this head/batch/cache block
+            lse_scratchpad_offsets = (
+                num_previous_sequences * lse_scratchpad_batch_stride
+                + query_split_offsets * lse_scratchpad_batch_stride
+                + kv_split_index * lse_scratchpad_kv_split_stride
+                + query_head_index
+            )
+
+            # Load log-sum-exp for this cache block, shape -> (cxpr_query_chunk_size,)
+            block_lse = _load(
+                lse_scratchpad_ptr + lse_scratchpad_offsets,
+                use_mask=needs_query_split_mask,
+                mask=query_split_mask,
+                other=float("-inf"),
+            )
+
+            # Reduce running max lse
+            m_ij = tl.maximum(m_i, block_lse).to(dtype)
+
+            # Calculate correction factor from previous cache blocks
+            # Note: exp() only accepts fp32/fp64 arguments
+            alpha = tl.exp((m_i - m_ij).to(tl.float32)).to(dtype)
+
+            # Apply correction factor
+            output *= alpha[:, None]
+
+            # Calculate correction factor from this cache block
+            # Note: exp() only accepts fp32/fp64 arguments
+            beta = tl.exp((block_lse - m_ij).to(tl.float32)).to(dtype)
+            # Apply second correction factor and accumulate running output
+            output += (beta[:, None] * block_output).to(dtype)
+
+            # Update running max
+            m_i = m_ij
+            # Update running final scale factor
+            l_i = l_i * alpha + beta
+
+    # Apply final correction to output
+    output /= l_i[:, None]
+
+    # Calculate offsets to store the output for this head/batch
+    output_offsets = (
+        num_previous_sequences * output_batch_stride
+        + query_split_offsets[:, None] * output_batch_stride
+        + query_head_index * output_head_stride
+        + head_offsets[None, :]
+    )
+
+    # Store final result
+    _store(
+        output_ptr + output_offsets,
+        output,
+        use_mask=needs_query_mask,
+        mask=query_mask,
+    )
+
+
+def _get_tuning_parameters() -> dict[str, int]:
+    """Get block sizes/tuning parameters for current device."""
+    device_name = torch.cuda.get_device_name() if torch.cuda.is_available() else ""
+
+    if "H100" in device_name:
+        return {
+            "query_chunk_size_stage1": 64,
+            "query_chunk_size_stage2": 64,
+        }
+
+    return {
+        "query_chunk_size_stage1": 32,
+        "query_chunk_size_stage2": 32,
+    }
+
+
+def varlen_attention_launcher(  # noqa: PLR0913
+    output: torch.Tensor,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    output_scratchpad: torch.Tensor,
+    lse_scratchpad: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    scale: float,
+    softcap: float = 0.0,
+    kv_cache_dtype: str = "auto",
+    causal: bool = False,
+) -> None:
+    """Varlen Attention kernel launcher.
+
+    Args:
+        output: Tensor to write the output of the attention calculation, shape: (total_num_q, num_heads, head_size).
+        query: Query tensor, shape: (total_num_q, num_heads, head_size).
+        key_cache: Tensor with cached K values, shape: (num_blocks, num_kv_heads, cache_block_size, head_size).
+        value_cache: Tensor with cached V values, shape: (num_blocks, num_kv_heads, cache_block_size, head_size).
+        output_scratchpad: Tensor used as scratchpad to share cache block outputs between two stages, shape: (total_num_q, max_num_blocks_per_sequence, num_query_heads, head_size)
+        lse_scratchpad: Tensor used as scratchpad to share cache block log-sum-exp between two stages, shape: (total_num_q, max_num_blocks_per_sequence, num_query_heads)
+        block_tables: Tensor storing the mapping from batch to cache blocks, shape: (batch_size, max_num_blocks_per_sequence).
+        seq_lens: Tensor with the sequence length of each index in the batch, shape: (batch_size, ).
+        cu_seqlens_q: Tensor, shape: (batch_size, ).
+        cu_seqlens_k: Tensor, shape: (batch_size, ).
+        max_seqlen_q: Scalar.
+        max_seqlen_k: Scalar.
+        scale: Scaling factor, 1/sqrt(head_size).
+        softcap: Logit softcap to apply (0.0 means no softcap will be applied).
+        kv_cache_dtype: If this dtype is fp8, apply scaling.
+    """
+    assert query.shape == output.shape  # noqa: S101
+    assert key_cache.shape == value_cache.shape  # noqa: S101
+    assert key_cache.stride(0) == value_cache.stride(0)  # noqa: S101
+    assert key_cache.stride(1) == value_cache.stride(1)  # noqa: S101
+    assert softcap >= 0.0  # noqa: S101
+
+    allowed_in_out_dtypes = [torch.float32, torch.float16, torch.bfloat16]
+    assert query.dtype in allowed_in_out_dtypes  # noqa: S101
+    assert output.dtype == query.dtype  # noqa: S101
+    assert output_scratchpad.dtype == query.dtype  # noqa: S101
+    assert lse_scratchpad.dtype == query.dtype  # noqa: S101
+
+    # Perform unchecked size accesses, assume has already been checked
+    total_num_q, num_query_heads, head_size = output.shape
+    num_cache_blocks, num_kv_heads, cache_block_size, _ = key_cache.shape
+    batch_size, max_num_blocks_per_sequence = block_tables.shape
+
+    assert cache_block_size == triton.next_power_of_2(cache_block_size), "Cache block size must be a power of two!"  # noqa: S101
+
+    # Need sizes to be constexpr in order to reshape tensors in kernel
+    cxpr_cache_block_size: tl.constexpr = cache_block_size
+    cxpr_head_size_padded: tl.constexpr = triton.next_power_of_2(head_size)
+
+    # For parity with Dao Flash Attention, softcap == 0.0 means no softcapping
+    cxpr_is_softcap: tl.constexpr = softcap > 0.0
+
+    cxpr_apply_fp8_scaling: tl.constexpr = kv_cache_dtype == "fp8" or kv_cache_dtype == "fp8_e4m3"
+    cxpr_is_rocm: tl.constexpr = current_platform.is_amd()
+
+    # How many query heads correspond to the same KV head?
+    query_group_size = num_query_heads // num_kv_heads
+
+    # What is the maximum number of stage 1 kernels to launch per batch/head?
+    # Each kernel processes up to {cache_block_size} tokens at a time (in many cases cache_block_size=32 for vLLM), so we can process
+    # a sequence up to {MAX_NUM_KV_SPLITS * cache_block_size} == 4 * 32 == 128 tokens before a stage 1 kernel will process multiple cache
+    # blocks. This helps to reduce the overhead of kernel launches / split reduction for long sequences.
+    # Note: we may need to tune this value for a given HW platform.
+    num_kv_splits = min(max_num_blocks_per_sequence, MAX_NUM_KV_SPLITS)
+
+    # Different platforms may require different query chunk sizes
+    tuning_parameters = _get_tuning_parameters()
+    query_chunk_size_stage1 = tuning_parameters["query_chunk_size_stage1"]
+    query_chunk_size_stage2 = tuning_parameters["query_chunk_size_stage2"]
+
+    # The "query chunk size" represents the number of queries that each kernel will process at a time.
+    num_query_splits_stage1 = triton.cdiv(max_seqlen_q, query_chunk_size_stage1)
+
+    # How many cache blocks will each kernel process?
+    num_cache_blocks_per_split = triton.cdiv(max_num_blocks_per_sequence, num_kv_splits)
+
+    # TODO(jmanning): Support KV8 scaling
+    k_scale_scalar = 1.0
+    v_scale_scalar = 1.0
+
+    # For computing attention for split block (stage 1): parallelize over batches, query splits, KV splits, and query heads.
+    stage1_grid = (batch_size, num_query_splits_stage1 * num_kv_splits, num_query_heads)
+
+    # Launch stage 1 kernel
+    _varlen_attention_compute_splits_kernel[stage1_grid](
+        # Relevant tensors
+        output_scratchpad_ptr=output_scratchpad,
+        lse_scratchpad_ptr=lse_scratchpad,
+        query_ptr=query,
+        key_cache_ptr=key_cache,
+        value_cache_ptr=value_cache,
+        block_tables_ptr=block_tables,
+        seq_lens_ptr=seq_lens,
+        cu_seqlens_q_ptr=cu_seqlens_q,
+        cu_seqlens_k_ptr=cu_seqlens_k,
+        # Scalars
+        scale=scale,
+        num_query_splits=num_query_splits_stage1,
+        num_cache_blocks_per_split=num_cache_blocks_per_split,
+        softcap=softcap,
+        k_scale=k_scale_scalar,
+        v_scale=v_scale_scalar,
+        head_size=head_size,
+        query_group_size=query_group_size,
+        # Strides of relevant tensors
+        output_scratchpad_batch_stride=output_scratchpad.stride(0),
+        output_scratchpad_kv_split_stride=output_scratchpad.stride(1),
+        output_scratchpad_head_stride=output_scratchpad.stride(2),
+        lse_scratchpad_batch_stride=lse_scratchpad.stride(0),
+        lse_scratchpad_kv_split_stride=lse_scratchpad.stride(1),
+        query_batch_stride=query.stride(0),
+        query_head_stride=query.stride(1),
+        kv_page_stride=key_cache.stride(0),
+        kv_head_stride=key_cache.stride(1),
+        kv_cache_block_stride=key_cache.stride(2),
+        kv_head_element_stride=key_cache.stride(3),
+        block_tables_batch_stride=block_tables.stride(0),
+        # Constexpr sizes
+        cxpr_query_chunk_size=query_chunk_size_stage1,
+        cxpr_cache_block_size=cxpr_cache_block_size,
+        cxpr_head_size_padded=cxpr_head_size_padded,
+        cxpr_is_softcap=cxpr_is_softcap,
+        cxpr_apply_fp8_scaling=cxpr_apply_fp8_scaling,
+        cxpr_is_rocm=cxpr_is_rocm,
+        cxpr_is_causal=causal,
+    )
+
+    # For reducing over splits (stage 2): parallelize over batches, query splits, and query heads
+    num_query_splits_stage2 = triton.cdiv(max_seqlen_q, query_chunk_size_stage2)
+    stage2_grid = (batch_size, num_query_splits_stage2, num_query_heads)
+
+    # Launch stage 2 kernel
+    _varlen_attention_reduce_splits_kernel[stage2_grid](
+        # Relevant tensors
+        output_ptr=output,
+        output_scratchpad_ptr=output_scratchpad,
+        lse_scratchpad_ptr=lse_scratchpad,
+        seq_lens_ptr=seq_lens,
+        cu_seqlens_q_ptr=cu_seqlens_q,
+        # Scalars
+        num_cache_blocks_per_split=num_cache_blocks_per_split,
+        head_size=head_size,
+        # Strides of relevant tensors
+        output_batch_stride=output.stride(0),
+        output_head_stride=output.stride(1),
+        output_scratchpad_batch_stride=output_scratchpad.stride(0),
+        output_scratchpad_kv_split_stride=output_scratchpad.stride(1),
+        output_scratchpad_head_stride=output_scratchpad.stride(2),
+        lse_scratchpad_batch_stride=lse_scratchpad.stride(0),
+        lse_scratchpad_kv_split_stride=lse_scratchpad.stride(1),
+        # Constexpr sizes
+        cxpr_query_chunk_size=query_chunk_size_stage2,
+        cxpr_cache_block_size=cxpr_cache_block_size,
+        cxpr_head_size_padded=cxpr_head_size_padded,
+        cxpr_is_causal=causal,
+    )

--- a/conch/ops/attention/varlen_attention.py
+++ b/conch/ops/attention/varlen_attention.py
@@ -1,0 +1,290 @@
+# Copyright (C) 2025 Stack AV Co. - All Rights Reserved.
+
+"""Flash Attention with varlen."""
+
+from dataclasses import dataclass
+from typing import Final
+
+import torch
+
+from conch.kernels.attention.varlen_attention import MAX_NUM_KV_SPLITS, varlen_attention_launcher
+
+
+@dataclass
+class VarlenAttentionMetadata:
+    """Wrapper class holding metadata for variable-length attention kernel."""
+
+    batch_size: int
+    num_query_heads: int
+    num_kv_heads: int
+    head_size: int
+    total_num_q: int
+    total_num_k: int
+    max_num_blocks_per_sequence: int
+
+
+def _check_output_query_size_compatibility(output: torch.Tensor, query: torch.Tensor) -> None:
+    """Check size compatibility of Output and Query tensors.
+
+    Args:
+        output: Tensor to write the output of the attention calculation, shape: (total_num_q, num_query_heads, head_size).
+        query: Query tensor, shape: (total_num_q, num_query_heads, head_size).
+
+    Raises:
+        ValueError if sizes are mismatched.
+    """
+    # Output tensor should be a 3-D tensor of shape (total_num_q, num_query_heads, head_size)
+    expected_output_shape_dims: Final = 3
+
+    if len(output.shape) != expected_output_shape_dims:
+        msg = f"Output tensor has unexpected shape ({output.shape = }), expected {expected_output_shape_dims}-D tensor"
+        raise ValueError(msg)
+
+    # Query tensor should have same shape as output
+    if len(query.shape) != expected_output_shape_dims:
+        msg = f"Query tensor has unexpected shape ({query.shape = }), expected {expected_output_shape_dims}-D tensor"
+        raise ValueError(msg)
+
+    if query.shape != output.shape:
+        msg = f"Shape of query and output tensors does not match ({query.shape = }, {output.shape = })"
+        raise ValueError(msg)
+
+
+def _check_key_value_cache_size_compatibility(
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    head_size: int,
+    num_query_heads: int,
+) -> None:
+    """Check size compatibility of Key and Value tensors.
+
+    Args:
+        key_cache: Tensor with cached K values, shape: (num_blocks, num_kv_heads, cache_block_size, head_size).
+        value_cache: Tensor with cached V values, shape: (num_blocks, num_kv_heads, cache_block_size, head_size).
+        head_size: Size of attention head, deduced from query tensor size.
+        num_query_heads: Number of query heads, deduced from query tensor size.
+
+    Raises:
+        ValueError if sizes are mismatched.
+    """
+    # Key/Value tensors should be 4-D tensors of shape (num_blocks, num_kv_heads, cache_block_size, head_size)
+    expected_key_shape_dims: Final = 4
+
+    if len(key_cache.shape) != expected_key_shape_dims:
+        msg = (
+            f"key_cache tensor has unexpected shape ({key_cache.shape = }), expected {expected_key_shape_dims}-D tensor"
+        )
+        raise ValueError(msg)
+
+    if len(value_cache.shape) != expected_key_shape_dims:
+        msg = f"value_cache tensor has unexpected shape ({value_cache.shape = }), expected {expected_key_shape_dims}-D tensor"
+        raise ValueError(msg)
+
+    if key_cache.shape != value_cache.shape:
+        msg = (
+            f"Shape of key_cache and value_cache tensors does not match ({key_cache.shape = }, {value_cache.shape = })"
+        )
+        raise ValueError(msg)
+
+    num_blocks, num_kv_heads, cache_block_size, head_size_kv = key_cache.shape
+
+    if head_size_kv != head_size:
+        msg = f"Head size of key/value cache tensors does not match head size of query/output tensors ({head_size_kv = }, {head_size = })"
+        raise ValueError(msg)
+
+    if num_kv_heads > num_query_heads:
+        msg = f"Number of key/value heads ({num_kv_heads}) is greater than number of query heads ({num_query_heads})"
+        raise ValueError(msg)
+
+
+def _check_cumulative_sequence_length_size_compatibility(
+    cu_seqlens_q: torch.Tensor, cu_seqlens_k: torch.Tensor
+) -> None:
+    """Check size compatibility of cumulative sequence length tensors.
+
+    Args:
+        cu_seqlens_q: Cumulative sequence length for query/output tensors, shape: (batch_size + 1).
+        cu_seqlens_k: Cumulative sequence length for key/value tensors, shape: (batch_size + 1).
+
+    Raises:
+        ValueError if sizes are mismatched.
+    """
+    # Cumulative sequence length tensors should be 1-D tensors of shape (batch_size + 1)
+    expected_cu_seqlen_shape_dims: Final = 1
+
+    if len(cu_seqlens_q.shape) != expected_cu_seqlen_shape_dims:
+        msg = f"Cumulative sequence length tensor for query has unexpected shape ({cu_seqlens_q.shape = }), expected {expected_cu_seqlen_shape_dims}-D tensor"
+        raise ValueError(msg)
+
+    if len(cu_seqlens_k.shape) != expected_cu_seqlen_shape_dims:
+        msg = f"Cumulative sequence length tensor for key has unexpected shape ({cu_seqlens_k.shape = }), expected {expected_cu_seqlen_shape_dims}-D tensor"
+        raise ValueError(msg)
+
+    if cu_seqlens_q.shape != cu_seqlens_k.shape:
+        msg = f"Shape of cumulative sequence length tensors does not match ({cu_seqlens_q.shape = }, {cu_seqlens_k.shape = })"
+        raise ValueError(msg)
+
+
+def _check_block_table_size_compatibility(block_tables: torch.Tensor, batch_size: int) -> None:
+    """Check size compatibility of block_tables tensor.
+
+    Args:
+        block_tables: Block tables tensor.
+        batch_size: Expected size of batch.
+
+    Raises:
+        ValueError if sizes are mismatched.
+    """
+    batch_size_block_tables: int = block_tables.shape[0]
+
+    if batch_size_block_tables != batch_size:
+        msg = f"Batch size from block_tables tensor ({batch_size_block_tables}) does not match batch_size from output/query tensors ({batch_size})"
+        raise ValueError(msg)
+
+
+def _check_seqlen_size_compatibility(seq_lens: torch.Tensor, batch_size: int) -> None:
+    """Check size compatibility of seq_lens tensor.
+
+    Args:
+        seq_lens: Sequence lengths tensor.
+        batch_size: Expected size of batch.
+
+    Raises:
+        ValueError if sizes are mismatched.
+    """
+    # Sequence lengths tensor should be 1-D tensors of shape (batch_size,)
+    expected_seqlen_shape_dims: Final = 1
+
+    if len(seq_lens.shape) != expected_seqlen_shape_dims:
+        msg = f"Sequence lengths tensor has unexpected shape ({seq_lens.shape = }), expected {expected_seqlen_shape_dims}-D tensor"
+        raise ValueError(msg)
+
+    if seq_lens.shape[0] != batch_size:
+        msg = f"Shape of sequence lengths tensor does not match batch size ({seq_lens.shape[0] = }, {batch_size = })"
+        raise ValueError(msg)
+
+
+def _check_size_compatibility(
+    out: torch.Tensor,
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+) -> VarlenAttentionMetadata:
+    """Check size compatibility of tensors for variable-length attention and return metadata if successful.
+
+    Args:
+        output: Tensor to write the output of the attention calculation, shape: (total_num_q, num_query_heads, head_size).
+        query: Query tensor, shape: (total_num_q, num_query_heads, head_size).
+        key_cache: Tensor with cached K values, shape: (num_blocks, num_kv_heads, cache_block_size, head_size).
+        value_cache: Tensor with cached V values, shape: (num_blocks, num_kv_heads, cache_block_size, head_size).
+        cu_seqlens_q: Cumulative sequence length for query/output tensors, shape: (batch_size + 1).
+        cu_seqlens_k: Cumulative sequence length for key/value tensors, shape: (batch_size + 1).
+        block_tables: Block tables tensor, shape: (batch_size, max_num_blocks_per_sequence).
+        seq_lens: Sequence lengths tensor, shape: (batch_size,).
+
+    Raises:
+        ValueError if sizes are mismatched.
+
+    Returns:
+        Metadata dataclass holding information about tensor sizes.
+    """
+    _check_output_query_size_compatibility(out, query)
+    total_num_q, num_query_heads, head_size = out.shape
+
+    _check_key_value_cache_size_compatibility(key_cache, value_cache, head_size, num_query_heads)
+    _, num_kv_heads, _, _ = key_cache.shape
+
+    _check_cumulative_sequence_length_size_compatibility(cu_seqlens_q, cu_seqlens_k)
+    batch_size = cu_seqlens_q.shape[0] - 1
+    total_num_k = int(cu_seqlens_k[-1].item())
+
+    _check_block_table_size_compatibility(block_tables, batch_size)
+    _, max_num_blocks_per_sequence = block_tables.shape
+
+    _check_seqlen_size_compatibility(seq_lens, batch_size)
+
+    return VarlenAttentionMetadata(
+        batch_size=batch_size,
+        num_query_heads=num_query_heads,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        total_num_q=total_num_q,
+        total_num_k=total_num_k,
+        max_num_blocks_per_sequence=max_num_blocks_per_sequence,
+    )
+
+
+def varlen_attention(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    block_tables: torch.Tensor,
+    seq_lens: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    scale: float,
+    softcap: float = 0.0,
+    causal: bool = False,
+) -> torch.Tensor:
+    """Varlen attention interface to verify sizes and launch kernel.
+
+    Args:
+        query: Query tensor, shape: (total_num_q, num_query_heads, head_size).
+        key_cache: Tensor with cached K values, shape: (num_blocks, num_kv_heads, cache_block_size, head_size).
+        value_cache: Tensor with cached V values, shape: (num_blocks, num_kv_heads, cache_block_size, head_size).
+        cu_seqlens_q: Cumulative sequence length for query/output tensors, shape: (batch_size + 1).
+        cu_seqlens_k: Cumulative sequence length for key/value tensors, shape: (batch_size + 1).
+        max_seqlen_q: Maximum sequence length for query/output tensors.
+        max_seqlen_k: Maximum sequence length for key/value tensors.
+        scale: Scaling factor, 1/sqrt(head_size).
+        softcap: (Optional), Logit softcap to apply (0.0 means no softcap will be applied).
+        causal: (Optional), Whether to apply causal masking.
+    """
+    # Allocate output tensor
+    output = torch.zeros_like(query, device=query.device, dtype=query.dtype)
+
+    # Check sizes of input tensors
+    metadata = _check_size_compatibility(
+        output, query, key_cache, value_cache, cu_seqlens_q, cu_seqlens_k, block_tables, seq_lens
+    )
+
+    # Allocate additional memory for intermediate result (of shape (head_size,)) for each batch/kv split/query head
+    output_scratchpad = torch.zeros(
+        (metadata.total_num_q, MAX_NUM_KV_SPLITS, metadata.num_query_heads, metadata.head_size),
+        dtype=output.dtype,
+        device=output.device,
+    )
+
+    # Allocate additional memory for intermediate log-sum-exp ("lse", scalar value per-cache block) for each batch/kv split/query head
+    lse_scratchpad = torch.zeros(
+        (metadata.total_num_q, MAX_NUM_KV_SPLITS, metadata.num_query_heads),
+        dtype=output.dtype,
+        device=output.device,
+    )
+
+    varlen_attention_launcher(
+        output=output,
+        query=query,
+        key_cache=key_cache,
+        value_cache=value_cache,
+        output_scratchpad=output_scratchpad,
+        lse_scratchpad=lse_scratchpad,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        scale=scale,
+        softcap=softcap,
+        kv_cache_dtype="auto",
+        causal=causal,
+    )
+
+    return output

--- a/tests/varlen_attention_test.py
+++ b/tests/varlen_attention_test.py
@@ -1,0 +1,483 @@
+# Copyright (C) 2025 Stack AV Co. - All Rights Reserved.
+
+"""Test Triton varlen attention."""
+
+import math
+from typing import Final
+
+import pytest
+import torch
+
+from conch import envs
+from conch.ops.attention.varlen_attention import varlen_attention
+from conch.platforms import current_platform
+from conch.third_party.vllm.utils import create_tensors, seed_everything
+
+_ENABLE_VLLM: Final = envs.CONCH_ENABLE_VLLM and current_platform.has_cuda()
+_HEAD_SIZES: Final = [64, 96, 128, 256]
+_NUM_SEQS_ABRIDGED: Final = [4, 10]
+# # MHA, MQA, and GQA
+# # - MHA: num_query_heads == num_kv_heads
+# # - MQA: num_kv_heads == 1
+# # - GQA: num_query_heads != num_kv_heads && num_kv_heads != 1
+_NUM_HEADS_ABRIDGED: Final = [(8, 8), (4, 1), (16, 4)]
+_SEQUENCE_LENGTHS: Final = [240, 343, 1024]
+
+
+def _get_tolerance_for_dtype(dtype: torch.dtype) -> float:
+    """Get expected tolerance to match to for a given dtype."""
+    if dtype == torch.float16:
+        return 5e-3
+
+    if dtype == torch.bfloat16:
+        return 3e-2
+
+    if dtype == torch.float32:
+        return 2e-3
+
+    msg = f"Unsupported dtype: '{dtype}'"
+    raise NotImplementedError(msg)
+
+
+def _convert_paged_to_contiguous(
+    k_cache_paged: torch.Tensor,
+    v_cache_paged: torch.Tensor,
+    block_tables: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    total_num_k: int,
+    num_kv_heads: int,
+    head_size: int,
+    cache_block_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Convert paged kv cache to contiguous.
+
+    Args:
+        k_cache_paged: Paged key cache.
+        v_cache_paged: Paged value cache.
+        block_tables: Block tables for traversing kv caches.
+        cu_seqlens_k: Sequence lengths.
+        num_kv_heads: The number of kv heads.
+        total_num_k: The total number of keys/values.
+        head_size: The dimension of the attention head.
+        cache_block_size: The size of each cache block.
+
+    Returns:
+        Tuple of key cache in contiguous memory and value cache in contiguous memory.
+    """
+    batch_size, _ = block_tables.shape
+
+    k_contiguous = torch.empty(
+        (total_num_k, num_kv_heads, head_size), dtype=k_cache_paged.dtype, device=k_cache_paged.device
+    )
+    v_contiguous = torch.empty(
+        (total_num_k, num_kv_heads, head_size), dtype=v_cache_paged.dtype, device=v_cache_paged.device
+    )
+
+    for batch_index in range(batch_size):
+        current_seq_len_begin = int(cu_seqlens_k[batch_index].item())
+        current_seq_len_end = int(cu_seqlens_k[batch_index + 1].item())
+        this_seqlen = current_seq_len_end - current_seq_len_begin
+
+        this_k = k_contiguous[current_seq_len_begin:current_seq_len_end]
+        this_v = v_contiguous[current_seq_len_begin:current_seq_len_end]
+
+        these_blocks = block_tables[batch_index]
+
+        relative_begin = 0
+
+        for relative_block_index, cache_block_index in enumerate(these_blocks):
+            current_k_block = k_cache_paged[cache_block_index]
+            current_v_block = v_cache_paged[cache_block_index]
+
+            relative_seqlen = relative_block_index * cache_block_size
+            if relative_seqlen >= this_seqlen:
+                break
+
+            # Relative end is the end index in the current cache block
+            relative_end = relative_begin + min(this_seqlen - relative_seqlen, cache_block_size)
+
+            this_length = relative_end - relative_begin
+
+            this_k_block = current_k_block.permute(1, 0, 2)
+            this_v_block = current_v_block.permute(1, 0, 2)
+
+            this_k[relative_begin:relative_end, :, :] = this_k_block[:this_length, :, :]
+            this_v[relative_begin:relative_end, :, :] = this_v_block[:this_length, :, :]
+
+            relative_begin += cache_block_size
+
+    return k_contiguous, v_contiguous
+
+
+def _attention_forward_core_ref_impl(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor, sm_scale: float, causal: bool, use_exp2: bool
+) -> tuple[torch.Tensor, torch.Tensor]:
+    original_dtype = q.dtype
+
+    # cast to float32
+    q = q.to(torch.float32)
+    k = k.to(torch.float32)
+    v = v.to(torch.float32)
+
+    # Compute attention scores
+    attention_scores = torch.matmul(q, k.transpose(-2, -1))
+
+    # Scale scores
+    attention_scaled_scores = sm_scale * attention_scores
+
+    # Apply causal mask if necessary
+    if causal:
+        L_q, L_k = q.shape[1], k.shape[1]
+        row_idx = torch.arange(L_q, device=q.device).unsqueeze(1)
+        col_idx = torch.arange(L_k, device=q.device).unsqueeze(0)
+        col_offset = L_q - L_k
+        causal_mask = row_idx >= (col_offset + col_idx)
+        # set -inf to places the causal mask is false
+        attention_scaled_scores = attention_scaled_scores.masked_fill(
+            torch.logical_not(causal_mask.unsqueeze(0)), float("-inf")
+        )
+
+    # Compute max for numerical stability
+    max_scores = torch.max(attention_scaled_scores, dim=-1, keepdim=True)[0]
+    if causal:
+        # Replace -inf in max_scores with zeros to avoid NaN in subtraction
+        max_scores = torch.where(torch.isinf(max_scores), torch.zeros_like(max_scores), max_scores)
+
+    # Shift scores
+    attention_shifted_scaled_scores = attention_scaled_scores - max_scores
+
+    # Exponentiate
+    if use_exp2:
+        RCP_LN = 1 / math.log(2)
+        exp_scores = torch.exp2(RCP_LN * attention_shifted_scaled_scores)
+    else:
+        exp_scores = torch.exp(attention_shifted_scaled_scores)
+
+    # Sum of exponentials
+    sum_exp_scores = torch.sum(exp_scores, dim=-1, keepdim=True)
+    if causal:
+        # if sum of exp scores is 0.0 it means scores where -inf, we cannot compute softmax and softmax_lse. Setting to 1 deals with -inf case cleanly
+        sum_exp_scores = torch.where(sum_exp_scores == 0, torch.ones_like(sum_exp_scores), sum_exp_scores)
+
+    # Compute softmax probabilities
+    p = exp_scores / sum_exp_scores
+
+    # Compute log-sum-exp
+    if use_exp2:
+        LN2 = math.log(2)
+        RCP_LN = 1 / math.log(2)
+        max_scores_base2 = max_scores * RCP_LN
+        softmax_lse_base2 = max_scores_base2 + torch.log2(sum_exp_scores)
+        softmax_lse = softmax_lse_base2 * LN2
+        softmax_lse.squeeze_(-1)
+    else:
+        softmax_lse = max_scores + torch.log(sum_exp_scores)
+        softmax_lse = softmax_lse.squeeze(-1)
+
+    # Compute output
+    o = torch.matmul(p, v)
+
+    # cast back to original dtype
+    o = o.to(original_dtype)
+
+    return o, softmax_lse
+
+
+def _attention_varlen_forward_pytorch_ref_impl(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    sm_scale: float,
+    causal: bool,
+    layout: str,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    use_exp2: bool = False,
+) -> torch.Tensor:
+    # Ensure the layout is 'thd'
+    if layout != "thd":
+        raise ValueError(f"Unsupported layout {layout}. Expected 'thd'.")
+
+    batch_size = cu_seqlens_q.shape[0] - 1
+    nheads_q, nheads_k = q.shape[1], k.shape[1]
+    head_dim = q.shape[2]
+
+    # Pre-allocate outputs
+    total_L_q = q.shape[0]
+
+    o = torch.zeros((total_L_q, nheads_q, head_dim), dtype=q.dtype, device=q.device)
+
+    # Compute group_size for MQA/GQA handling
+    group_size = nheads_q // nheads_k
+    if nheads_q % nheads_k != 0:
+        raise ValueError("nheads_q must be divisible by nheads_k")
+
+    for i in range(batch_size):
+        # Get the start and end indices for the current sequence
+        start_q = int(cu_seqlens_q[i].item())
+        end_q = int(cu_seqlens_q[i + 1].item())
+        start_k = int(cu_seqlens_k[i].item())
+        end_k = int(cu_seqlens_k[i + 1].item())
+
+        seqlen_q = end_q - start_q
+        seqlen_k = end_k - start_k
+
+        # Extract q_i, k_i, v_i
+        q_i = q[start_q:end_q, :, :]  # [L_q_i, nheads_q, head_dim]
+        k_i = k[start_k:end_k, :, :]  # [L_k_i, nheads_k, head_dim]
+        v_i = v[start_k:end_k, :, :]  # [L_k_i, nheads_k, head_dim]
+
+        # Permute to [nheads, L_q_i, head_dim]
+        q_i = q_i.permute(1, 0, 2)
+        k_i = k_i.permute(1, 0, 2)
+        v_i = v_i.permute(1, 0, 2)
+
+        # Handle MQA/GQA by adjusting shapes based on group_size
+        if group_size != 1:
+            # Reshape q_i to [nheads_k, group_size, L_q_i, head_dim]
+            q_i = q_i.reshape(nheads_k, group_size, seqlen_q, head_dim)
+            # Expand k_i and v_i to match group_size
+            k_i = k_i.unsqueeze(1).expand(-1, group_size, -1, -1)
+            v_i = v_i.unsqueeze(1).expand(-1, group_size, -1, -1)
+            # Flatten the first two dimensions for computation
+            q_i = q_i.reshape(nheads_k * group_size, seqlen_q, head_dim)
+            k_i = k_i.reshape(nheads_k * group_size, seqlen_k, head_dim)
+            v_i = v_i.reshape(nheads_k * group_size, seqlen_k, head_dim)
+        else:
+            # Standard case
+            q_i = q_i.reshape(nheads_q, seqlen_q, head_dim)
+            k_i = k_i.reshape(nheads_k, seqlen_k, head_dim)
+            v_i = v_i.reshape(nheads_k, seqlen_k, head_dim)
+
+        # Call the core attention function for this sequence
+        o_i, _ = _attention_forward_core_ref_impl(q_i, k_i, v_i, sm_scale, causal, use_exp2)
+
+        # Reshape outputs back to original dimensions
+        if group_size != 1:
+            # Reshape outputs to [nheads_k, group_size, seqlen_q, head_dim]
+            o_i = o_i.reshape(nheads_k, group_size, seqlen_q, head_dim)
+            # Combine the first two dimensions back to nheads_q
+            o_i = o_i.reshape(nheads_q, seqlen_q, head_dim)
+        else:
+            # Outputs are already in the correct shape
+            pass
+
+        # Convert back to 'thd' layout
+        o_i = o_i.permute(1, 0, 2)  # [L_q_i, nheads_q, head_dim]
+
+        # Place outputs in pre-allocated tensors
+        o[start_q:end_q, :, :] = o_i
+
+    return o
+
+
+@pytest.mark.parametrize("num_seqs", _NUM_SEQS_ABRIDGED)
+@pytest.mark.parametrize("head_size", _HEAD_SIZES)
+@pytest.mark.parametrize(("num_query_heads", "num_kv_heads"), _NUM_HEADS_ABRIDGED)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("sequence_length", _SEQUENCE_LENGTHS)
+@pytest.mark.parametrize("causal", [True, False])
+def test_varlen_attention_vs_pytorch(
+    num_seqs: int,
+    head_size: int,
+    num_query_heads: int,
+    num_kv_heads: int,
+    dtype: torch.dtype,
+    sequence_length: int,
+    causal: bool,
+) -> None:
+    """Test Varlen Attention Triton kernel with various configurations vs. vLLM FlashAttnVarlen."""
+    seed: Final = 0
+    seed_everything(seed)
+
+    device: Final = torch.device(current_platform.device)
+    torch.set_default_device(device)
+
+    scale: Final = float(1.0 / (head_size**0.5))
+    softcap: Final = 0.0
+
+    tolerance: Final = _get_tolerance_for_dtype(dtype)
+
+    kv_cache_dtype: Final = "auto"
+
+    cache_block_size = 16
+
+    _, _, _, key_cache_conch, value_cache_conch, block_tables, seq_lens = create_tensors(
+        head_size,
+        sequence_length,
+        cache_block_size,
+        num_seqs,
+        num_query_heads,
+        num_kv_heads,
+        kv_cache_dtype,
+        current_platform.device,
+        dtype,
+    )
+
+    starting_item = torch.as_tensor([0], dtype=torch.int32)
+
+    cu_seqlens_q = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
+    cu_seqlens_q = torch.cat((starting_item, cu_seqlens_q), dim=0)
+
+    cu_seqlens_k = cu_seqlens_q.clone()
+
+    max_seqlen_q = int(torch.max(seq_lens).item())
+    max_seqlen_k = int(max_seqlen_q)
+
+    total_num_q = int(cu_seqlens_q[-1].item())
+    total_num_k = int(cu_seqlens_k[-1].item())
+
+    key_contiguous, value_contiguous = _convert_paged_to_contiguous(
+        key_cache_conch,
+        value_cache_conch,
+        block_tables,
+        cu_seqlens_k,
+        total_num_k,
+        num_kv_heads,
+        head_size,
+        cache_block_size,
+    )
+
+    q = torch.empty(total_num_q, num_query_heads, head_size, dtype=dtype, device=device)
+    q.uniform_(-scale, scale)
+
+    pytorch_output = _attention_varlen_forward_pytorch_ref_impl(
+        q=q,
+        k=key_contiguous,
+        v=value_contiguous,
+        sm_scale=scale,
+        causal=causal,
+        layout="thd",
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+    )
+
+    conch_output = varlen_attention(
+        query=q,
+        key_cache=key_cache_conch,
+        value_cache=value_cache_conch,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        scale=scale,
+        softcap=softcap,
+        causal=causal,
+    )
+
+    torch.testing.assert_close(pytorch_output, conch_output, atol=tolerance, rtol=tolerance)
+
+
+@pytest.mark.skipif(not _ENABLE_VLLM, reason="This test case requires vLLM")
+@pytest.mark.parametrize("num_seqs", _NUM_SEQS_ABRIDGED)
+@pytest.mark.parametrize("head_size", _HEAD_SIZES)
+@pytest.mark.parametrize(("num_query_heads", "num_kv_heads"), _NUM_HEADS_ABRIDGED)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("sequence_length", _SEQUENCE_LENGTHS)
+@pytest.mark.parametrize("causal", [True, False])
+@pytest.mark.parametrize("is_pure_decode", [True, False])
+def test_varlen_attention_vs_flash_attn(
+    num_seqs: int,
+    head_size: int,
+    num_query_heads: int,
+    num_kv_heads: int,
+    dtype: torch.dtype,
+    sequence_length: int,
+    causal: bool,
+    is_pure_decode: bool,
+) -> None:
+    """Test Varlen Attention Triton kernel with various configurations vs. vLLM FlashAttnVarlen."""
+    from vllm.vllm_flash_attn import flash_attn_varlen_func  # type: ignore[attr-defined, unused-ignore]
+
+    seed: Final = 0
+    seed_everything(seed)
+
+    device: Final = torch.device(current_platform.device)
+    torch.set_default_device(device)
+
+    scale: Final = float(1.0 / (head_size**0.5))
+    softcap: Final = 0.0
+
+    tolerance: Final = _get_tolerance_for_dtype(dtype)
+
+    kv_cache_dtype: Final = "auto"
+
+    cache_block_size = 16
+
+    _, _, _, key_cache_conch, value_cache_conch, block_tables, seq_lens = create_tensors(
+        head_size,
+        sequence_length,
+        cache_block_size,
+        num_seqs,
+        num_query_heads,
+        num_kv_heads,
+        kv_cache_dtype,
+        current_platform.device,
+        dtype,
+    )
+
+    starting_item = torch.as_tensor([0], dtype=torch.int32)
+
+    if is_pure_decode:
+        seqlens_q = torch.ones((num_seqs,), dtype=torch.int32)
+
+        cu_seqlens_q = torch.cumsum(seqlens_q, dim=0, dtype=torch.int32)
+        cu_seqlens_q = torch.cat((starting_item, cu_seqlens_q), dim=0)
+
+        cu_seqlens_k = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
+        cu_seqlens_k = torch.cat((starting_item, cu_seqlens_k), dim=0)
+
+        max_seqlen_q = int(torch.max(seqlens_q).item())
+        max_seqlen_k = int(torch.max(seq_lens).item())
+    else:
+        cu_seqlens_q = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
+        cu_seqlens_q = torch.cat((starting_item, cu_seqlens_q), dim=0)
+
+        cu_seqlens_k = cu_seqlens_q.clone()
+
+        max_seqlen_q = int(torch.max(seq_lens).item())
+        max_seqlen_k = int(max_seqlen_q)
+
+    key_cache_fa = key_cache_conch.permute(0, 2, 1, 3)
+    value_cache_fa = value_cache_conch.permute(0, 2, 1, 3)
+
+    total_num_q = int(cu_seqlens_q[-1].item())
+
+    q = torch.empty(total_num_q, num_query_heads, head_size, dtype=dtype, device=device)
+    q.uniform_(-scale, scale)
+
+    vllm_output = flash_attn_varlen_func(
+        q=q,
+        k=key_cache_fa,
+        v=value_cache_fa,
+        cu_seqlens_q=cu_seqlens_q,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        block_table=block_tables,
+        seqused_k=seq_lens,
+        softmax_scale=scale,
+        causal=causal,
+    )
+
+    conch_output = varlen_attention(
+        query=q,
+        key_cache=key_cache_conch,
+        value_cache=value_cache_conch,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        scale=scale,
+        softcap=softcap,
+        causal=causal,
+    )
+
+    torch.testing.assert_close(vllm_output, conch_output, atol=tolerance, rtol=tolerance)


### PR DESCRIPTION
### Description

This PR adds a Triton `varlen_attention` implementation.

### Testing

Please select all that apply.

- [ ] Existing unit tests
- [x] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```bash
CONCH_ENABLE_VLLM=1 pytest tests/varlen_attention_test.py
```

```bash
864 passed in 87.61s (0:01:27)
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [ ] AMD GPU
- [ ] Other (please explain)

#### Benchmarks

**A10**

```bash
CONCH_ENABLE_VLLM=1 python benchmarks/varlen_attention_benchmark.py
```

```bash
Results matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 10, 'num_query_heads': 8, 'num_kv_heads': 4, 'causal': False, 'pure_decode': False}
Triton: num_iterations=100, min=2.516 ms, max=2.686 ms, mean=2.551 ms, median=2.544 ms
Baseline: num_iterations=100, min=0.784 ms, max=0.889 ms, mean=0.854 ms, median=0.881 ms
```

```bash
CONCH_ENABLE_VLLM=1 python benchmarks/varlen_attention_benchmark.py --causal
```

```bash
Results matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 10, 'num_query_heads': 8, 'num_kv_heads': 4, 'causal': True, 'pure_decode': False}
Triton: num_iterations=100, min=1.740 ms, max=1.888 ms, mean=1.798 ms, median=1.791 ms
Baseline: num_iterations=100, min=0.485 ms, max=0.526 ms, mean=0.507 ms, median=0.509 ms
```