### PR TITLE
Remove cu_seqlens_k from varlen attention

### DIFF
--- a/benchmarks/varlen_attention_benchmark.py
+++ b/benchmarks/varlen_attention_benchmark.py
@@ -192,16 +192,12 @@ def main(
         cu_seqlens_q = torch.cumsum(seqlens_q, dim=0, dtype=torch.int32)
         cu_seqlens_q = torch.cat((starting_item, cu_seqlens_q), dim=0)
 
-        cu_seqlens_k = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
-        cu_seqlens_k = torch.cat((starting_item, cu_seqlens_k), dim=0)
-
         max_seqlen_q = int(torch.max(seqlens_q).item())
         max_seqlen_k = int(torch.max(seq_lens).item())
     else:
         cu_seqlens_q = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
 
         cu_seqlens_q = torch.cat((starting_item, cu_seqlens_q), dim=0)
-        cu_seqlens_k = cu_seqlens_q.clone()
 
         max_seqlen_q = int(torch.max(seq_lens).item())
         max_seqlen_k = int(max_seqlen_q)
@@ -215,12 +211,11 @@ def main(
         query=query,
         key_cache=key_cache,
         value_cache=value_cache,
-        block_table=block_table,
-        seq_lens=seq_lens,
         cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=max_seqlen_q,
+        seq_lens=seq_lens,
         max_seqlen_k=max_seqlen_k,
+        block_table=block_table,
         scale=scale,
         causal=causal,
     )
@@ -308,13 +303,12 @@ def main(
             query=query,
             key_cache=key_cache,
             value_cache=value_cache,
-            block_table=block_table,
-            seq_lens=seq_lens,
-            output=output_conch,
             cu_seqlens_q=cu_seqlens_q,
-            cu_seqlens_k=cu_seqlens_k,
             max_seqlen_q=max_seqlen_q,
+            seq_lens=seq_lens,
             max_seqlen_k=max_seqlen_k,
+            block_table=block_table,
+            output=output_conch,
             scale=scale,
             causal=causal,
         ),

--- a/conch/kernels/attention/varlen_attention.py
+++ b/conch/kernels/attention/varlen_attention.py
@@ -681,12 +681,11 @@ def varlen_attention_launcher(  # noqa: PLR0913
     query: torch.Tensor,
     key_cache: torch.Tensor,
     value_cache: torch.Tensor,
-    block_table: torch.Tensor,
-    seq_lens: torch.Tensor,
     cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
     max_seqlen_q: int,
+    seq_lens: torch.Tensor,
     max_seqlen_k: int,
+    block_table: torch.Tensor,
     output_scratchpad: torch.Tensor | None = None,
     lse_scratchpad: torch.Tensor | None = None,
     causal: bool = False,
@@ -703,12 +702,11 @@ def varlen_attention_launcher(  # noqa: PLR0913
         query: Query tensor, shape: (total_num_q, num_heads, head_size).
         key_cache: Tensor with cached K values, shape: (num_blocks, cache_block_size, num_kv_heads, head_size).
         value_cache: Tensor with cached V values, shape: (num_blocks, cache_block_size, num_kv_heads, head_size).
-        block_table: Tensor storing the mapping from batch to cache blocks, shape: (batch_size, max_num_blocks_per_sequence).
-        seq_lens: Tensor with the sequence length of each index in the batch, shape: (batch_size, ).
         cu_seqlens_q: Tensor with the cumulative query sequence lengths for each index in the batch, shape: (batch_size + 1, ).
-        cu_seqlens_k: Tensor with the cumulative key/value sequence lengths for each index in the batch, shape: (batch_size + 1, ).
         max_seqlen_q: Maximum sequence length of the query.
+        seq_lens: Tensor with the sequence length of each index in the batch, shape: (batch_size, ).
         max_seqlen_k: Maximum sequence length of the key/value.
+        block_table: Tensor storing the mapping from batch to cache blocks, shape: (batch_size, max_num_blocks_per_sequence).
         output_scratchpad: Tensor used as scratchpad to share cache block outputs between two stages, shape: (total_num_q, num_kv_splits, num_query_heads, head_size)
         lse_scratchpad: Tensor used as scratchpad to share cache block log-sum-exp between two stages, shape: (total_num_q, num_kv_splits, num_query_heads)
         causal: Whether or not to apply causal masking.

--- a/tests/varlen_attention_test.py
+++ b/tests/varlen_attention_test.py
@@ -298,12 +298,11 @@ def test_varlen_attention_vs_pytorch(
         query=q,
         key_cache=key_cache,
         value_cache=value_cache,
-        block_table=block_table,
-        seq_lens=seq_lens,
         cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=max_seqlen_q,
+        seq_lens=seq_lens,
         max_seqlen_k=max_seqlen_k,
+        block_table=block_table,
         causal=causal,
         scale=scale,
         softcap=softcap,
@@ -368,16 +367,11 @@ def test_varlen_attention_vs_flash_attn(
         cu_seqlens_q = torch.cumsum(seqlens_q, dim=0, dtype=torch.int32)
         cu_seqlens_q = torch.cat((starting_item, cu_seqlens_q), dim=0)
 
-        cu_seqlens_k = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
-        cu_seqlens_k = torch.cat((starting_item, cu_seqlens_k), dim=0)
-
         max_seqlen_q = int(torch.max(seqlens_q).item())
         max_seqlen_k = int(torch.max(seq_lens).item())
     else:
         cu_seqlens_q = torch.cumsum(seq_lens, dim=0, dtype=torch.int32)
         cu_seqlens_q = torch.cat((starting_item, cu_seqlens_q), dim=0)
-
-        cu_seqlens_k = cu_seqlens_q.clone()
 
         max_seqlen_q = int(torch.max(seq_lens).item())
         max_seqlen_k = int(max_seqlen_q)
@@ -404,12 +398,11 @@ def test_varlen_attention_vs_flash_attn(
         query=q,
         key_cache=key_cache,
         value_cache=value_cache,
-        block_table=block_table,
-        seq_lens=seq_lens,
         cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_k,
         max_seqlen_q=max_seqlen_q,
+        seq_lens=seq_lens,
         max_seqlen_k=max_seqlen_k,
+        block_table=block_table,
         causal=causal,
         scale=scale,
         softcap=softcap,
@@ -505,12 +498,11 @@ def test_vllm_crash(dtype: torch.dtype) -> None:
         query=q,
         key_cache=key_cache,
         value_cache=value_cache,
-        block_table=block_table,
-        seq_lens=seq_lens,
         cu_seqlens_q=cu_seqlens_q,
-        cu_seqlens_k=cu_seqlens_q,
         max_seqlen_q=max_seqlen_q,
+        seq_lens=seq_lens,
         max_seqlen_k=max_seqlen_k,
+        block_table=block_table,
         causal=causal,
         scale=scale,
         softcap=softcap,


### PR DESCRIPTION
### Description

This PR cleans up arguments passed to varlen attention kernel

### Testing

Please select all that apply.

- [x] Existing unit tests
- [ ] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```
# If vLLM is installed, add CONCH_ENABLE_VLLM=1 
pytest tests/varlen_attention_test.py
python benchmarks/varlen_attention_benchmark.py
python benchmarks/varlen_attention_benchmark.py --causal
```

**A10**

```
1442 passed in 141.62s (0:02:21)
```

```
INFO 06-09 12:39:31 [importing.py:53] Triton module has been replaced with a placeholder.
INFO 06-09 12:39:33 [__init__.py:239] Automatically detected platform cuda.
Results matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 10, 'num_query_heads': 8, 'num_kv_heads': 4, 'causal': False, 'pure_decode': False}
Triton: num_iterations=100, min=1.598 ms, max=1.673 ms, mean=1.611 ms, median=1.609 ms
Baseline: num_iterations=100, min=0.783 ms, max=0.899 ms, mean=0.860 ms, median=0.889 ms
```

```
INFO 06-09 12:39:10 [importing.py:53] Triton module has been replaced with a placeholder.
INFO 06-09 12:39:11 [__init__.py:239] Automatically detected platform cuda.
Results matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 10, 'num_query_heads': 8, 'num_kv_heads': 4, 'causal': True, 'pure_decode': False}
Triton: num_iterations=100, min=0.888 ms, max=0.916 ms, mean=0.898 ms, median=0.897 ms
Baseline: num_iterations=100, min=0.482 ms, max=0.534 ms, mean=0.512 ms, median=0.523 ms
```

**H100**

```
1442 passed in 119.77s (0:01:59)
```

```
INFO 06-09 16:40:38 [importing.py:53] Triton module has been replaced with a placeholder.
INFO 06-09 16:40:39 [__init__.py:239] Automatically detected platform cuda.
Results matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 10, 'num_query_heads': 8, 'num_kv_heads': 4, 'causal': False, 'pure_decode': False}
Triton: num_iterations=100, min=0.727 ms, max=0.830 ms, mean=0.742 ms, median=0.740 ms
Baseline: num_iterations=100, min=0.216 ms, max=0.225 ms, mean=0.222 ms, median=0.222 ms
```

```
INFO 06-09 16:41:05 [importing.py:53] Triton module has been replaced with a placeholder.
INFO 06-09 16:41:06 [__init__.py:239] Automatically detected platform cuda.
Results matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 10, 'num_query_heads': 8, 'num_kv_heads': 4, 'causal': True, 'pure_decode': False}
Triton: num_iterations=100, min=0.476 ms, max=0.564 ms, mean=0.494 ms, median=0.492 ms
Baseline: num_iterations=100, min=0.146 ms, max=0.163 ms, mean=0.153 ms, median=0.153 ms
```

**MI300X**

```
480 passed, 962 skipped in 107.96s (0:01:47)
```

```
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 256, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 10, 'num_query_heads': 8, 'num_kv_heads': 4, 'causal': False, 'pure_decode': False}
Triton: num_iterations=100, min=0.449 ms, max=0.510 ms, mean=0.461 ms, median=0.460 ms
```

```
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 256, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 10, 'num_query_heads': 8, 'num_kv_heads': 4, 'causal': True, 'pure_decode': False}
Triton: num_iterations=100, min=0.418 ms, max=0.440 ms, mean=0.426 ms, median=0.426 ms
vLLM Triton: num_iterations=100, min=1.198 ms, max=1.293 ms, mean=1.233 ms, median=1.227 ms
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [x] AMD GPU
- [ ] Other (please explain)
