### PR TITLE
Remove dependency on vLLM ScalarType for mixed_precision_gemm interface

### DIFF
--- a/benchmarks/mixed_precision_gemm_benchmark.py
+++ b/benchmarks/mixed_precision_gemm_benchmark.py
@@ -209,7 +209,9 @@ def main(
 
     output_ref = torch.matmul(a, w_ref)
 
-    triton_output = mixed_precision_gemm(a, w_q, w_s, None, weight_dtype_vllm, group_size)
+    triton_output = mixed_precision_gemm(
+        a, w_q, w_s, None, weight_dtype_vllm.size_bits, weight_dtype_vllm.bias, group_size
+    )
 
     # Relax atol as our reduction dim becomes larger (more rounding error)
     atol = min(5e-2 * math.sqrt(k_dim), 1)
@@ -261,7 +263,9 @@ def main(
         baseline_result = None
 
     triton_result = benchmark_it(
-        lambda: mixed_precision_gemm(a, w_q, w_s, None, weight_dtype_vllm, group_size),
+        lambda: mixed_precision_gemm(
+            a, w_q, w_s, None, weight_dtype_vllm.size_bits, weight_dtype_vllm.bias, group_size
+        ),
         tag="Triton",
         metadata=metadata,
         num_iterations=num_iterations,

--- a/conch/kernels/quantization/gemm.py
+++ b/conch/kernels/quantization/gemm.py
@@ -15,7 +15,6 @@ import triton
 import triton.language as tl
 
 from conch.platforms import current_platform
-from conch.third_party.vllm.scalar_type import ScalarType
 
 
 class DType(Enum):
@@ -485,7 +484,7 @@ class MixedPrecisionMatmulMetadata:
     m_dim: int
     k_dim: int
     n_dim: int
-    weight_type: ScalarType
+    weight_size_bits: int
     weight_bias: int
     group_size: int
     elements_per_sample: int
@@ -530,7 +529,7 @@ def mixed_precision_gemm_launcher(
         k_dim=metadata.k_dim,
         n_dim=metadata.n_dim,
         # Quantization paramers
-        cxpr_w_nbits=metadata.weight_type.size_bits,
+        cxpr_w_nbits=metadata.weight_size_bits,
         cxpr_weight_bias=metadata.weight_bias,
         cxpr_group_size=metadata.group_size,
         cxpr_unpack_mask=metadata.unpack_mask,

--- a/tests/mixed_precision_gemm_test.py
+++ b/tests/mixed_precision_gemm_test.py
@@ -69,7 +69,9 @@ def test_gemm(
 
     output_ref = torch.matmul(a, w_ref)
 
-    triton_output = mixed_precision_gemm(a, w_q_packed, w_s, w_zp, weight_dtype, group_size)
+    triton_output = mixed_precision_gemm(
+        a, w_q_packed, w_s, w_zp, weight_dtype.size_bits, weight_dtype.bias, group_size
+    )
 
     atol = min(5e-2 * math.sqrt(k_dim), 1)
     torch.testing.assert_close(triton_output, output_ref, rtol=1e-1, atol=atol)


### PR DESCRIPTION
### Description

This PR removes the dependency on vLLM's `ScalarType` class for the public interface of `mixed_precision_gemm`. This will make it easier to provide support for Conch's mixed_precision_gemm inside of vLLM.

### Testing

Please select all that apply.

- [x] Existing unit tests
- [ ] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```
pytest tests/mixed_precision_gemm_test.py
```

```
# On H100, add CONCH_ENABLE_VLLM=1 and --enable-machete
python benchmarks/mixed_precision_gemm_benchmark.py
```

**A10**

```
48 passed in 4.07s
```

```
Results matched :)
Parameters: {'m_dim': 4096, 'k_dim': 8192, 'n_dim': 4096, 'input_dtype': 'fp16', 'weight_dtype': 'uint4b8'}
Triton: num_iterations=100, min=10.580 ms, max=16.913 ms, mean=11.023 ms, median=10.757 ms
```

**H100**

```
48 passed in 8.03s
```

```
INFO 06-09 17:19:37 [importing.py:53] Triton module has been replaced with a placeholder.
INFO 06-09 17:19:38 [__init__.py:239] Automatically detected platform cuda.
Results matched :)
Parameters: {'m_dim': 4096, 'k_dim': 8192, 'n_dim': 4096, 'input_dtype': 'fp16', 'weight_dtype': 'uint4b8'}
Triton: num_iterations=100, min=1.756 ms, max=1.944 ms, mean=1.794 ms, median=1.783 ms
Baseline: num_iterations=100, min=0.438 ms, max=0.474 ms, mean=0.450 ms, median=0.443 ms
```

**MI300X**

```
48 passed in 16.07s
```

```
Results matched :)
Parameters: {'m_dim': 4096, 'k_dim': 8192, 'n_dim': 4096, 'input_dtype': 'fp16', 'weight_dtype': 'uint4b8'}
Triton: num_iterations=100, min=1.219 ms, max=1.424 ms, mean=1.270 ms, median=1.258 ms
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [x] AMD GPU
- [ ] Other (please explain)
