### PR TITLE
Fix FP8 support

### DIFF
--- a/conch/reference/vllm/reshape_and_cache.py
+++ b/conch/reference/vllm/reshape_and_cache.py
@@ -37,10 +37,8 @@ def _reshape_and_cache_pytorch_ref(
         block_idx = block_indicies_lst[i]
         block_offset = block_offsets_lst[i]
         if kv_cache_dtype == "fp8":
-            key_cache[block_idx, :, :, block_offset, :] = (
-                (reshaped_key[i] * k_scale_scalar).to(fp8_dtype).view(torch.uint8)
-            )
-            value_cache[block_idx, :, :, block_offset] = (value[i] * v_scale_scalar).to(fp8_dtype).view(torch.uint8)
+            key_cache[block_idx, :, :, block_offset, :] = (reshaped_key[i] * k_scale_scalar).to(fp8_dtype)
+            value_cache[block_idx, :, :, block_offset] = (value[i] * v_scale_scalar).to(fp8_dtype)
         else:
             key_cache[block_idx, :, :, block_offset, :] = reshaped_key[i]
             value_cache[block_idx, :, :, block_offset] = value[i]

--- a/conch/third_party/vllm/unified_attention.py
+++ b/conch/third_party/vllm/unified_attention.py
@@ -52,11 +52,11 @@ def kernel_unified_attention_2d(
     stride_k_cache_0: tl.int64,  # int
     stride_k_cache_1: tl.int64,  # int
     stride_k_cache_2: tl.int64,  # int
-    stride_k_cache_3: tl.int64,  # int
+    stride_k_cache_3: tl.constexpr,  # int
     stride_v_cache_0: tl.int64,  # int
     stride_v_cache_1: tl.int64,  # int
     stride_v_cache_2: tl.int64,  # int
-    stride_v_cache_3: tl.int64,  # int
+    stride_v_cache_3: tl.constexpr,  # int
     query_start_len_ptr,  # [num_seqs+1]
     BLOCK_Q: tl.constexpr,  # int
     num_seqs: tl.int32,

--- a/docs/getting_started/developer_environment.md
+++ b/docs/getting_started/developer_environment.md
@@ -92,6 +92,6 @@ Most unit tests/benchmarks allow comparison to CUDA implementations of operation
 In order to use them, you can install vLLM (`pip install vllm`) and set the environment variable `CONCH_ENABLE_VLLM=1`.
 
 ```bash
-pip install vllm==0.8.5
+pip install vllm==0.9.1
 CONCH_ENABLE_VLLM=1 python benchmarks/paged_attention_benchmark.py
 ```

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from typing import Final
 
 from setuptools import setup
 
-_TORCH_VERSION: Final = "2.6.0"
+_TORCH_VERSION: Final = "2.7.0"
 
 _REQUIREMENTS: Final = [
     "numpy>=1.26.4",
@@ -15,21 +15,21 @@ _REQUIREMENTS: Final = [
 # --extra-index-url https://download.pytorch.org/whl/cpu
 _DEFAULT_PLATFORM_REQUIREMENTS: Final = [
     f"torch=={_TORCH_VERSION}",
-    "triton>=3.1.0",
+    "triton>=3.3.0",
 ]
 
 # For ROCm:
 # --extra-index-url https://download.pytorch.org/whl/rocm6.2.4
 _ROCM_PLATFORM_REQUIREMENTS: Final = [
     f"torch=={_TORCH_VERSION}+rocm6.2.4",
-    "pytorch-triton-rocm>=3.1.0",
+    "pytorch-triton-rocm>=3.3.0",
 ]
 
 # For XPU:
 # --extra-index-url https://download.pytorch.org/whl/xpu
 _XPU_PLATFORM_REQUIREMENTS: Final = [
     f"torch=={_TORCH_VERSION}+xpu",
-    "pytorch-triton-xpu>=3.2.0",
+    "pytorch-triton-xpu>=3.3.0",
 ]
 
 _PLATFORM_REQUIREMENTS: Final = {

--- a/tools/create_benchmark_results_table.py
+++ b/tools/create_benchmark_results_table.py
@@ -92,14 +92,15 @@ def main(results_directory: Path, use_cached_results: bool) -> None:
 
             with results_csv.open("w") as results_file:
                 run(
-                    ["python", f"benchmarks/{benchmark_name}.py", "--csv", "--num-iterations", "10000"],
+                    ["python", f"benchmarks/{benchmark_name}.py", "--csv"],
                     check=True,
                     stdout=results_file,
+                    env=os.environ,
                 )
 
         # Read the CSV file
         df = pd.read_csv(results_csv)
-        triton_df = df[df["tag"] == "Triton"]
+        triton_df = df[df["tag"] == "Conch"]
         baseline_df = df[df["tag"] == "Baseline"]
 
         # Calculate speedup


### PR DESCRIPTION
### Description

This PR fixes FP8 support in varlen and reshape_and_cache and upgrades to vLLM==0.9.1.

### Testing

Please select all that apply.

- [x] Existing unit tests
- [ ] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```
# On A10/H100, add `CONCH_ENABLE_VLLM=1`
pytest
```

**A10**

```
20221 passed, 9204 skipped in 818.20s (0:13:38)
```

**H100**

```
26929 passed, 2544 skipped in 379.01s (0:06:19)
```

**MI300X**

```
1619 passed, 27854 skipped in 297.55s (0:04:57)
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [x] AMD GPU
- [ ] Other (please explain)
