### PR TITLE
More varlen optimizations

### DIFF
--- a/conch/ops/attention/varlen_attention.py
+++ b/conch/ops/attention/varlen_attention.py
@@ -140,13 +140,16 @@ def _check_seqlen_size_compatibility(seq_lens: torch.Tensor, batch_size: int) ->
 
 def _determine_max_num_kv_splits(max_seqlen_q: int, max_seqlen_k: int, max_num_blocks_per_sequence: int) -> int:
     # If we have any prefills (max_seqlen_q > 1), disable FlashDecoding/KV-splits.
-    # If we have all decodes, only enable FlashDecoding if we have a long sequence (>=2048 tokens) and
-    # many cache blocks for each sequence (>=16 cache blocks for the longest sequence).
-    # Note: this is a pretty basic heuristic, we could try and do something more sophisticated in the future
-    if max_seqlen_q > 1 and max_seqlen_k >= 2048 and max_num_blocks_per_sequence >= 16:
+    # If we have all decodes, only enable FlashDecoding if we have a long sequence (>=4096 tokens) and
+    # many cache blocks for each sequence (>=64 cache blocks for the longest sequence).
+    # Note: this is a pretty basic heuristic, we could try and do something more sophisticated in the future. It'd
+    # probably be more efficient to tune this per-platform, but we can't just autotune it because it determines how
+    # much scratchpad memory we allocate. FlashAttention's heuristic uses the number of SMs, it might be worth
+    # considering something like that, but preferably platform-agnostic.
+    if max_seqlen_q == 1 and max_seqlen_k >= 4096 and max_num_blocks_per_sequence >= 64:
         # This number of KV splits affects the size of the scratchpad memory that we allocate,
         # so cap the number of splits at 64 so that we don't allocate too much memory
-        return min(max_num_blocks_per_sequence // 4, 64)
+        return min(max_num_blocks_per_sequence // 16, 64)
 
     return 1
 

--- a/tools/benchmarks/collect_varlen_attention_decode.sh
+++ b/tools/benchmarks/collect_varlen_attention_decode.sh
@@ -25,6 +25,8 @@ sequence_lengths=(
   "8192"
   "16384"
   "32768"
+  "65536"
+  "131072"
 )
 
 for seq_len in ${sequence_lengths[@]}; do


### PR DESCRIPTION
### Description

This PR contains more fixes/optimizations for varlen. First it fixes a bug where FlashDecoding was never used. Then we have an optimization because we noticed that the conditional load/store helper functions seem to be much more efficient on MI300X than H100. There's also some small differences in the intermediate datatype representations we use.

### Testing

Please select all that apply.

- [x] Existing unit tests
- [ ] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```
# Add CONCH_ENABLE_VLLM=1 on Nvidia
pytest tests/varlen_attention_test.py
```

**A10**

```
1490 passed, 1008 skipped in 119.05s (0:01:59)
```

**H100**

```
2498 passed in 192.81s (0:03:12)
```

**MI300X**

```
480 passed, 2018 skipped in 61.40s (0:01:01)
```

#### Benchmarking

**A10**

_Prefill_
```
jmanning@a10:~/conch$ CONCH_BENCH_NO_CSV=1 ./tools/benchmarks/collect_varlen_attention_prefill.sh
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 32, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=10736, min=0.377 ms, max=0.471 ms, mean=0.387 ms, median=0.387 ms
vLLM Triton: num_iterations=9944, min=0.441 ms, max=0.507 ms, mean=0.454 ms, median=0.455 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 64, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=7622, min=0.775 ms, max=0.867 ms, mean=0.792 ms, median=0.793 ms
vLLM Triton: num_iterations=6268, min=1.183 ms, max=1.405 ms, mean=1.216 ms, median=1.213 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 128, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=4064, min=1.942 ms, max=2.059 ms, mean=1.972 ms, median=1.968 ms
vLLM Triton: num_iterations=3067, min=3.312 ms, max=3.542 ms, mean=3.375 ms, median=3.370 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 256, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=1675, min=5.523 ms, max=5.717 ms, mean=5.565 ms, median=5.584 ms
vLLM Triton: num_iterations=999, min=10.490 ms, max=11.138 ms, mean=10.680 ms, median=10.690 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 512, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=556, min=17.291 ms, max=17.692 ms, mean=17.499 ms, median=17.489 ms
vLLM Triton: num_iterations=270, min=36.405 ms, max=37.889 ms, mean=36.853 ms, median=36.854 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=163, min=60.069 ms, max=61.561 ms, mean=60.653 ms, median=60.746 ms
vLLM Triton: num_iterations=75, min=131.242 ms, max=135.432 ms, mean=132.977 ms, median=132.909 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 2048, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=44, min=222.012 ms, max=224.701 ms, mean=223.456 ms, median=223.461 ms
vLLM Triton: num_iterations=19, min=499.029 ms, max=504.270 ms, mean=502.108 ms, median=503.002 ms
```

_Decode_
```
jmanning@a10:~/conch$ CONCH_BENCH_NO_CSV=1 ./tools/benchmarks/collect_varlen_attention_prefill.sh
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 32, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=10736, min=0.377 ms, max=0.471 ms, mean=0.387 ms, median=0.387 ms
vLLM Triton: num_iterations=9944, min=0.441 ms, max=0.507 ms, mean=0.454 ms, median=0.455 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 64, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=7622, min=0.775 ms, max=0.867 ms, mean=0.792 ms, median=0.793 ms
vLLM Triton: num_iterations=6268, min=1.183 ms, max=1.405 ms, mean=1.216 ms, median=1.213 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 128, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=4064, min=1.942 ms, max=2.059 ms, mean=1.972 ms, median=1.968 ms
vLLM Triton: num_iterations=3067, min=3.312 ms, max=3.542 ms, mean=3.375 ms, median=3.370 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 256, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=1675, min=5.523 ms, max=5.717 ms, mean=5.565 ms, median=5.584 ms
vLLM Triton: num_iterations=999, min=10.490 ms, max=11.138 ms, mean=10.680 ms, median=10.690 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 512, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=556, min=17.291 ms, max=17.692 ms, mean=17.499 ms, median=17.489 ms
vLLM Triton: num_iterations=270, min=36.405 ms, max=37.889 ms, mean=36.853 ms, median=36.854 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=163, min=60.069 ms, max=61.561 ms, mean=60.653 ms, median=60.746 ms
vLLM Triton: num_iterations=75, min=131.242 ms, max=135.432 ms, mean=132.977 ms, median=132.909 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 2048, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=44, min=222.012 ms, max=224.701 ms, mean=223.456 ms, median=223.461 ms
vLLM Triton: num_iterations=19, min=499.029 ms, max=504.270 ms, mean=502.108 ms, median=503.002 ms
```

**H100**

_Prefill_
```
jmanning@h100:~/conch$ CONCH_BENCH_NO_CSV=1 tools/benchmarks/collect_varlen_attention_prefill.sh
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 32, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=43614, min=0.112 ms, max=0.729 ms, mean=0.116 ms, median=0.115 ms
vLLM Triton: num_iterations=20533, min=0.128 ms, max=1.222 ms, mean=0.130 ms, median=0.130 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 64, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=30078, min=0.217 ms, max=0.221 ms, mean=0.218 ms, median=0.218 ms
vLLM Triton: num_iterations=19732, min=0.283 ms, max=1.283 ms, mean=0.286 ms, median=0.286 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 128, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=16345, min=0.492 ms, max=0.496 ms, mean=0.494 ms, median=0.494 ms
vLLM Triton: num_iterations=11504, min=0.731 ms, max=0.735 ms, mean=0.733 ms, median=0.733 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 256, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=7067, min=1.291 ms, max=1.296 ms, mean=1.294 ms, median=1.294 ms
vLLM Triton: num_iterations=4213, min=2.223 ms, max=2.229 ms, mean=2.225 ms, median=2.225 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 512, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=2501, min=3.878 ms, max=4.935 ms, mean=3.883 ms, median=3.882 ms
vLLM Triton: num_iterations=1281, min=7.461 ms, max=7.524 ms, mean=7.503 ms, median=7.521 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=749, min=13.215 ms, max=14.286 ms, mean=13.223 ms, median=13.221 ms
vLLM Triton: num_iterations=361, min=27.496 ms, max=27.503 ms, mean=27.500 ms, median=27.500 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 2048, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=207, min=48.106 ms, max=49.141 ms, mean=48.122 ms, median=48.117 ms
vLLM Triton: num_iterations=95, min=105.041 ms, max=105.050 ms, mean=105.046 ms, median=105.046 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 4096, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=54, min=183.042 ms, max=184.127 ms, mean=183.083 ms, median=183.060 ms
vLLM Triton: num_iterations=24, min=410.592 ms, max=410.799 ms, mean=410.754 ms, median=410.791 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 8192, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=14, min=708.572 ms, max=708.777 ms, mean=708.646 ms, median=708.590 ms
vLLM Triton: num_iterations=6, min=1610.080 ms, max=1611.143 ms, mean=1610.439 ms, median=1610.109 ms
```

_Decode_
```
jmanning@h100:~/conch$ CONCH_BENCH_NO_CSV=1 ./tools/benchmarks/collect_varlen_attention_decode.sh
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 32, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=55390, min=0.061 ms, max=2.632 ms, mean=0.073 ms, median=0.069 ms
vLLM Triton: num_iterations=22581, min=0.053 ms, max=0.588 ms, mean=0.067 ms, median=0.064 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 64, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=55527, min=0.019 ms, max=3.527 ms, mean=0.079 ms, median=0.075 ms
vLLM Triton: num_iterations=21584, min=0.057 ms, max=1.326 ms, mean=0.069 ms, median=0.067 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 128, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=54611, min=0.025 ms, max=3.473 ms, mean=0.081 ms, median=0.077 ms
vLLM Triton: num_iterations=51905, min=0.056 ms, max=3.400 ms, mean=0.072 ms, median=0.070 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 256, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=54604, min=0.037 ms, max=2.294 ms, mean=0.078 ms, median=0.074 ms
vLLM Triton: num_iterations=52046, min=0.053 ms, max=1.168 ms, mean=0.070 ms, median=0.067 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 512, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=52236, min=0.066 ms, max=3.858 ms, mean=0.081 ms, median=0.078 ms
vLLM Triton: num_iterations=21667, min=0.060 ms, max=2.014 ms, mean=0.071 ms, median=0.068 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=44527, min=0.107 ms, max=0.235 ms, mean=0.112 ms, median=0.112 ms
vLLM Triton: num_iterations=43477, min=0.104 ms, max=0.251 ms, mean=0.109 ms, median=0.109 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 2048, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=30711, min=0.201 ms, max=0.226 ms, mean=0.209 ms, median=0.208 ms
vLLM Triton: num_iterations=31067, min=0.193 ms, max=0.222 ms, mean=0.202 ms, median=0.202 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 4096, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=19877, min=0.370 ms, max=0.379 ms, mean=0.374 ms, median=0.374 ms
vLLM Triton: num_iterations=17248, min=0.367 ms, max=1.474 ms, mean=0.383 ms, median=0.382 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 8192, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=11893, min=0.714 ms, max=0.722 ms, mean=0.717 ms, median=0.717 ms
vLLM Triton: num_iterations=11416, min=0.715 ms, max=1.807 ms, mean=0.742 ms, median=0.741 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 16384, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=6566, min=1.397 ms, max=1.408 ms, mean=1.401 ms, median=1.401 ms
vLLM Triton: num_iterations=6356, min=1.411 ms, max=2.533 ms, mean=1.462 ms, median=1.458 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 32768, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=3438, min=2.778 ms, max=2.791 ms, mean=2.783 ms, median=2.783 ms
vLLM Triton: num_iterations=3248, min=2.808 ms, max=3.133 ms, mean=2.904 ms, median=2.897 ms
```

**MI300X**

_Prefill_
```
jmanning@mi300x:~/conch$ CONCH_BENCH_NO_CSV=1  ./tools/benchmarks/collect_varlen_attention_prefill.sh
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 32, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=18804, min=0.438 ms, max=9.218 ms, mean=0.442 ms, median=0.441 ms
vLLM Triton: num_iterations=24293, min=0.276 ms, max=13.097 ms, mean=0.281 ms, median=0.280 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 64, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=10170, min=0.875 ms, max=9.728 ms, mean=0.887 ms, median=0.885 ms
vLLM Triton: num_iterations=12044, min=0.672 ms, max=13.579 ms, mean=0.686 ms, median=0.682 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 128, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=5828, min=1.544 ms, max=14.605 ms, mean=1.559 ms, median=1.554 ms
vLLM Triton: num_iterations=5031, min=1.772 ms, max=15.232 ms, mean=1.845 ms, median=1.831 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 256, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=2595, min=3.646 ms, max=16.936 ms, mean=3.724 ms, median=3.713 ms
vLLM Triton: num_iterations=1761, min=5.528 ms, max=18.926 ms, mean=5.648 ms, median=5.613 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 512, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=935, min=10.470 ms, max=21.873 ms, mean=10.604 ms, median=10.569 ms
vLLM Triton: num_iterations=534, min=18.750 ms, max=32.129 ms, mean=19.027 ms, median=18.908 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=268, min=34.741 ms, max=44.938 ms, mean=35.170 ms, median=35.114 ms
vLLM Triton: num_iterations=145, min=68.580 ms, max=79.189 ms, mean=69.321 ms, median=69.004 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 2048, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=79, min=123.936 ms, max=135.236 ms, mean=125.539 ms, median=125.445 ms
vLLM Triton: num_iterations=37, min=259.911 ms, max=276.578 ms, mean=264.755 ms, median=263.158 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 4096, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=20, min=480.781 ms, max=495.217 ms, mean=485.288 ms, median=484.916 ms
vLLM Triton: num_iterations=9, min=1023.223 ms, max=1052.244 ms, mean=1037.928 ms, median=1039.041 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 8192, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': False}
Conch: num_iterations=5, min=1916.183 ms, max=1926.559 ms, mean=1918.625 ms, median=1916.593 ms
vLLM Triton: num_iterations=2, min=4143.172 ms, max=4182.140 ms, mean=4162.656 ms, median=4182.140 ms
```

_Decode_
```
jmanning@mi300x:~/conch$ CONCH_BENCH_NO_CSV=1 ./tools/benchmarks/collect_varlen_attention_decode.sh
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 32, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=64747, min=0.022 ms, max=12.596 ms, mean=0.099 ms, median=0.098 ms
vLLM Triton: num_iterations=54394, min=0.042 ms, max=13.052 ms, mean=0.093 ms, median=0.092 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 64, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=62891, min=0.045 ms, max=13.518 ms, mean=0.100 ms, median=0.099 ms
vLLM Triton: num_iterations=53892, min=0.052 ms, max=12.618 ms, mean=0.093 ms, median=0.091 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 128, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=61624, min=0.037 ms, max=9.526 ms, mean=0.097 ms, median=0.095 ms
vLLM Triton: num_iterations=50907, min=0.066 ms, max=15.361 ms, mean=0.090 ms, median=0.087 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 256, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=60707, min=0.060 ms, max=0.418 ms, mean=0.093 ms, median=0.092 ms
vLLM Triton: num_iterations=42956, min=0.097 ms, max=9.548 ms, mean=0.099 ms, median=0.099 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 512, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=47342, min=0.109 ms, max=8.014 ms, mean=0.121 ms, median=0.121 ms
vLLM Triton: num_iterations=34303, min=0.159 ms, max=13.610 ms, mean=0.164 ms, median=0.163 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 1024, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=32577, min=0.202 ms, max=12.486 ms, mean=0.218 ms, median=0.217 ms
vLLM Triton: num_iterations=23602, min=0.284 ms, max=12.896 ms, mean=0.291 ms, median=0.289 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 2048, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=20127, min=0.385 ms, max=9.163 ms, mean=0.408 ms, median=0.407 ms
vLLM Triton: num_iterations=14952, min=0.519 ms, max=13.497 ms, mean=0.528 ms, median=0.525 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 4096, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=10662, min=0.817 ms, max=13.693 ms, mean=0.848 ms, median=0.845 ms
vLLM Triton: num_iterations=8603, min=0.998 ms, max=14.155 ms, mean=1.019 ms, median=1.012 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 8192, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=5869, min=1.495 ms, max=14.555 ms, mean=1.547 ms, median=1.540 ms
vLLM Triton: num_iterations=4756, min=1.949 ms, max=15.469 ms, mean=1.991 ms, median=1.973 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 16384, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=3603, min=2.514 ms, max=11.429 ms, mean=2.633 ms, median=2.626 ms
vLLM Triton: num_iterations=2452, min=3.904 ms, max=17.495 ms, mean=4.008 ms, median=3.968 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 32768, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=1483, min=4.484 ms, max=17.939 ms, mean=4.612 ms, median=4.594 ms
vLLM Triton: num_iterations=1239, min=7.881 ms, max=21.563 ms, mean=8.094 ms, median=8.086 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 65536, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=1108, min=8.417 ms, max=18.488 ms, mean=8.780 ms, median=8.808 ms
vLLM Triton: num_iterations=628, min=15.806 ms, max=29.810 ms, mean=16.219 ms, median=16.165 ms
Skipping checking vs. reference vLLM implementation...
Parameters: {'head_dim': 128, 'seq_len': 131072, 'cache_block_size': 32, 'batch_size': 128, 'num_query_heads': 128, 'num_kv_heads': 8, 'causal': True, 'pure_decode': True}
Conch: num_iterations=564, min=17.203 ms, max=27.393 ms, mean=17.658 ms, median=17.622 ms
vLLM Triton: num_iterations=289, min=31.583 ms, max=42.542 ms, mean=32.219 ms, median=31.970 ms
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [x] AMD GPU
- [ ] Other (please explain)
