### PR TITLE
Undo grid changes to reshape_and_cache

### DIFF
--- a/tools/benchmarks/collect_reshape_and_cache.sh
+++ b/tools/benchmarks/collect_reshape_and_cache.sh
@@ -2,10 +2,10 @@
 # Copyright 2025 Stack AV Co.
 # SPDX-License-Identifier: Apache-2.0
 
+# Specify CONCH_ENABLE_VLLM=1 to compare against vLLM ref impl (if installed)
 # Specify CONCH_BENCH_NO_CSV=1 to print results to stdout instead of file
 
 # Need to enable vLLM to compare against vLLM CUDA implementation
-export CONCH_ENABLE_VLLM=1
 export VLLM_LOGGING_LEVEL=CRITICAL
 
 # Create output directory
@@ -14,11 +14,12 @@ benchmark_dir="results/$benchmark_name"
 mkdir -p $benchmark_dir
 
 num_tokens=(
-  "32"
   "64"
   "128"
-  "256"
   "512"
+  "2048"
+  "8192"
+  "32768"
 )
 
 for tokens in ${num_tokens[@]}; do


### PR DESCRIPTION
### Description

The grid change was a performance pessimization for small input sizes (<2048 tokens) so reverting it. Plus, the Conch performance is still slightly better than CUDA for larger sizes as well, even with the 2D grid.

### Testing

Please select all that apply.

- [x] Existing unit tests
- [ ] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```
pytest
```

#### Benchmarks

**H100**

```
CONCH_BENCH_NO_CSV=1 CONCH_ENABLE_VLLM=1 ./tools/benchmarks/collect_reshape_and_cache.sh
```

_Before_

```
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 64, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=75989, min=0.013 ms, max=0.784 ms, mean=0.022 ms, median=0.020 ms
Baseline: num_iterations=97134, min=0.007 ms, max=0.418 ms, mean=0.008 ms, median=0.008 ms
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 128, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=78969, min=0.012 ms, max=3.211 ms, mean=0.021 ms, median=0.019 ms
Baseline: num_iterations=96695, min=0.008 ms, max=0.275 ms, mean=0.008 ms, median=0.008 ms
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 512, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=74210, min=0.014 ms, max=1.166 ms, mean=0.022 ms, median=0.020 ms
Baseline: num_iterations=94177, min=0.010 ms, max=0.414 ms, mean=0.011 ms, median=0.011 ms
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 2048, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=75971, min=0.018 ms, max=0.770 ms, mean=0.027 ms, median=0.025 ms
Baseline: num_iterations=83511, min=0.024 ms, max=0.029 ms, mean=0.025 ms, median=0.024 ms
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 8192, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=63021, min=0.051 ms, max=0.158 ms, mean=0.053 ms, median=0.053 ms
Baseline: num_iterations=59291, min=0.072 ms, max=0.473 ms, mean=0.073 ms, median=0.073 ms
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 32768, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=33438, min=0.187 ms, max=0.192 ms, mean=0.190 ms, median=0.190 ms
Baseline: num_iterations=27805, min=0.264 ms, max=0.269 ms, mean=0.265 ms, median=0.266 ms
```

_After_

```
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 64, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=83395, min=0.006 ms, max=2.491 ms, mean=0.015 ms, median=0.006 ms
Baseline: num_iterations=97388, min=0.007 ms, max=2.480 ms, mean=0.008 ms, median=0.008 ms
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 128, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=112872, min=0.006 ms, max=2.514 ms, mean=0.013 ms, median=0.007 ms
Baseline: num_iterations=110533, min=0.007 ms, max=2.497 ms, mean=0.020 ms, median=0.008 ms
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 512, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=79005, min=0.008 ms, max=2.572 ms, mean=0.025 ms, median=0.009 ms
Baseline: num_iterations=94628, min=0.009 ms, max=2.566 ms, mean=0.024 ms, median=0.011 ms
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 2048, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=98955, min=0.016 ms, max=3.793 ms, mean=0.048 ms, median=0.019 ms
Baseline: num_iterations=94092, min=0.020 ms, max=2.581 ms, mean=0.047 ms, median=0.025 ms
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 8192, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=70954, min=0.053 ms, max=4.895 ms, mean=0.170 ms, median=0.059 ms
Baseline: num_iterations=64478, min=0.069 ms, max=4.911 ms, mean=0.383 ms, median=0.073 ms
Key cache matched with atol=0.001 :)
Value cache matched with atol=0.001 :)
Parameters: {'head_dim': 256, 'num_tokens': 32768, 'cache_block_size': 32, 'num_kv_heads': 8, 'num_blocks': 2000, 'kv_cache_dtype': 'auto'}
Conch: num_iterations=32103, min=0.225 ms, max=2.801 ms, mean=0.472 ms, median=0.231 ms
Baseline: num_iterations=28712, min=0.260 ms, max=2.824 ms, mean=0.496 ms, median=0.266 ms
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [x] AMD GPU
- [ ] Other (please explain)
