### PR TITLE
Add torch.compile() option

### DIFF
--- a/benchmarks/static_scaled_fp8_quant_benchmark.py
+++ b/benchmarks/static_scaled_fp8_quant_benchmark.py
@@ -74,6 +74,16 @@ def _dequantize(quantized_tensor: torch.Tensor, inv_scale: float, dtype: torch.d
     is_flag=True,
     help="Flag for printing results in CSV format",
 )
+@click.option(
+    "--compile-ref",
+    is_flag=True,
+    help="Flag to torch.compile() the reference impl",
+)
+@click.option(
+    "--compile-conch",
+    is_flag=True,
+    help="Flag to torch.compile() the Conch impl",
+)
 def main(
     hidden_size: int,
     num_tokens: int,
@@ -83,6 +93,8 @@ def main(
     verbose: bool,
     gpu: str,
     csv: bool,
+    compile_ref: bool,
+    compile_conch: bool,
 ) -> None:
     """Benchmark static scaled FP8 quantization.
 
@@ -95,6 +107,8 @@ def main(
         verbose: Flag to indicate whether or not to print verbose output.
         gpu: Which gpu to run on.
         csv: Flag to indicate whether or not to print results in CSV format.
+        compile_ref: Flag to torch.compile() the reference implementation.
+        compile_conch: Flag to torch.compile() the Conch implementation.
     """
     if not current_platform.supports_fp8():
         error_msg = "FP8 not supported on this GPU, cannot run benchmark!"
@@ -119,8 +133,11 @@ def main(
     x = torch.rand(num_tokens, hidden_size, dtype=dtype, device=device)
     scale_arg = torch.tensor([scale], dtype=torch.float32, device=device)
 
-    reference_output = scaled_fp8_quant_reference(x, scale_arg)
-    conch_output, _ = scaled_fp8_quant_conch(x, scale_arg)
+    scaled_fp8_quant_conch_fn = torch.compile(scaled_fp8_quant_conch) if compile_conch else scaled_fp8_quant_conch
+    scaled_fp8_quant_ref_fn = torch.compile(scaled_fp8_quant_reference) if compile_ref else scaled_fp8_quant_reference
+
+    reference_output = scaled_fp8_quant_ref_fn(x, scale_arg)
+    conch_output, _ = scaled_fp8_quant_conch_fn(x, scale_arg)
 
     if not torch.allclose(_dequantize(reference_output, scale, dtype), _dequantize(conch_output, scale, dtype)):
         print("WARNING: Reference and Conch results differ!", file=sys.stderr)
@@ -134,7 +151,7 @@ def main(
 
     # Benchmark Reference vs. Conch implementations
     baseline_result = benchmark_it(
-        lambda: scaled_fp8_quant_reference(x, scale_arg),
+        lambda: scaled_fp8_quant_ref_fn(x, scale_arg),
         tag="Baseline",
         metadata=metadata,
         iteration_time_ms=iteration_time_ms,
@@ -142,7 +159,7 @@ def main(
     )
 
     conch_result = benchmark_it(
-        lambda: scaled_fp8_quant_conch(x, scale_arg),
+        lambda: scaled_fp8_quant_conch_fn(x, scale_arg),
         tag="Conch",
         metadata=metadata,
         iteration_time_ms=iteration_time_ms,

--- a/benchmarks/static_scaled_int8_quant_benchmark.py
+++ b/benchmarks/static_scaled_int8_quant_benchmark.py
@@ -69,6 +69,16 @@ from conch.utils.benchmark import BenchmarkMetadata, benchmark_it
     is_flag=True,
     help="Flag for printing results in CSV format",
 )
+@click.option(
+    "--compile-ref",
+    is_flag=True,
+    help="Flag to torch.compile() the reference impl",
+)
+@click.option(
+    "--compile-conch",
+    is_flag=True,
+    help="Flag to torch.compile() the Conch impl",
+)
 def main(
     hidden_size: int,
     num_tokens: int,
@@ -78,6 +88,8 @@ def main(
     verbose: bool,
     gpu: str,
     csv: bool,
+    compile_ref: bool,
+    compile_conch: bool,
 ) -> None:
     """Benchmark static scaled int8 quantization.
 
@@ -90,6 +102,8 @@ def main(
         verbose: Flag to indicate whether or not to print verbose output.
         gpu: Which gpu to run on.
         csv: Flag to indicate whether or not to print results in CSV format.
+        compile_ref: Flag to torch.compile() the reference implementation.
+        compile_conch: Flag to torch.compile() the Conch implementation.
     """
     seed: Final = 0
     seed_everything(seed)
@@ -110,8 +124,13 @@ def main(
     x = torch.rand(num_tokens, hidden_size, dtype=dtype, device=device) * 1000
     scale_arg = torch.tensor([scale], dtype=torch.float32, device=device)
 
-    ref_output = scaled_int8_quant_reference(x, scale_arg)
-    conch_output, _ = scaled_int8_quant_conch(x, scale_arg)
+    scaled_int8_quant_ref_fn = (
+        torch.compile(scaled_int8_quant_reference) if compile_ref else scaled_int8_quant_reference
+    )
+    scaled_int8_quant_conch_fn = torch.compile(scaled_int8_quant_conch) if compile_conch else scaled_int8_quant_conch
+
+    ref_output = scaled_int8_quant_ref_fn(x, scale_arg)
+    conch_output, _ = scaled_int8_quant_conch_fn(x, scale_arg)
 
     if not torch.allclose(ref_output, conch_output, atol=1, rtol=0.0):
         print("WARNING: Reference and Conch results differ!", file=sys.stderr)
@@ -124,7 +143,7 @@ def main(
         print("Results matched :)", file=sys.stderr)
 
     baseline_result = benchmark_it(
-        lambda: scaled_int8_quant_reference(
+        lambda: scaled_int8_quant_ref_fn(
             x,
             scale_arg,
         ),
@@ -135,7 +154,7 @@ def main(
     )
 
     conch_result = benchmark_it(
-        lambda: scaled_int8_quant_conch(
+        lambda: scaled_int8_quant_conch_fn(
             x,
             scale_arg,
         ),

--- a/conch/reference/vllm/reshape_and_cache.py
+++ b/conch/reference/vllm/reshape_and_cache.py
@@ -20,27 +20,18 @@ def _reshape_and_cache_pytorch_ref(
     v_scale: torch.Tensor,
 ) -> None:
     """Reference PyTorch-only implementation of reshape_and_cache."""
-    num_tokens, _, _ = key.shape
+    num_tokens = slot_mapping.size(0)
     _, block_size, _, _ = key_cache.shape
 
     if kv_cache_dtype == "fp8":
-        k_scale_scalar = 1.0 / k_scale
-        v_scale_scalar = 1.0 / v_scale
         fp8_dtype = torch.float8_e4m3fnuz if current_platform.is_amd() else torch.float8_e4m3fn
+        key = (key / k_scale).to(fp8_dtype).view(key_cache.dtype)
+        value = (value / v_scale).to(fp8_dtype).view(value_cache.dtype)
 
     block_indicies = torch.div(slot_mapping, block_size, rounding_mode="floor")
-    block_indicies_lst = block_indicies.cpu().tolist()
     block_offsets = slot_mapping % block_size
-    block_offsets_lst = block_offsets.cpu().tolist()
-    for i in range(num_tokens):
-        block_idx = block_indicies_lst[i]
-        block_offset = block_offsets_lst[i]
-        if kv_cache_dtype == "fp8":
-            key_cache[block_idx, block_offset, :, :] = (key[i] * k_scale_scalar).to(fp8_dtype)
-            value_cache[block_idx, block_offset, :, :] = (value[i] * v_scale_scalar).to(fp8_dtype)
-        else:
-            key_cache[block_idx, block_offset, :, :] = key[i]
-            value_cache[block_idx, block_offset, :, :] = value[i]
+    key_cache[block_indicies, block_offsets, :, :] = key[:num_tokens]
+    value_cache[block_indicies, block_offsets, :, :] = value[:num_tokens]
 
 
 def _reshape_and_cache_vllm_ref(


### PR DESCRIPTION
### Description

Adds option to torch.compile() pytorch reference implementations. In many cases it offers similar performance to our hand-written kernels.

### Testing

Please select all that apply.

- [ ] Existing unit tests
- [ ] Unit tests added by this PR
- [x] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```
python benchmarks/{name}.py --compile-ref
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [x] AMD GPU
- [ ] Other (please explain)
