### PR TITLE
Convert to floor_divide

### DIFF
--- a/conch/reference/vllm/reshape_and_cache.py
+++ b/conch/reference/vllm/reshape_and_cache.py
@@ -28,7 +28,7 @@ def _reshape_and_cache_pytorch_ref(
         key = (key / k_scale).to(fp8_dtype).view(key_cache.dtype)
         value = (value / v_scale).to(fp8_dtype).view(value_cache.dtype)
 
-    block_indicies = torch.div(slot_mapping, block_size, rounding_mode="floor")
+    block_indicies = torch.floor_divide(slot_mapping, block_size)
     block_offsets = slot_mapping % block_size
     key_cache[block_indicies, block_offsets, :, :] = key[:num_tokens]
     value_cache[block_indicies, block_offsets, :, :] = value[:num_tokens]


### PR DESCRIPTION
### Description

Changes reshape_and_cache impl to use floor_divide instead of `div(mode="floor")`

### Testing

Please select all that apply.

- [x] Existing unit tests
- [ ] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```
pytest
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [x] AMD GPU
- [ ] Other (please explain)
