### PR TITLE
Add Non-Max Suppression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ dist/
 results/
 
 .coverage
+.vscode

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Each operation is complete with a PyTorch-only reference implementation (and som
   - GEMM
     - Mixed-precision
     - Scaled
+- Vision
+  - Non-Max Suppression (NMS)
 - vLLM
   - KV cache operations
     - Copy blocks
@@ -99,6 +101,7 @@ We were inspired by and leverage components of the following libraries:
 
 - [bitsandbytes](https://github.com/bitsandbytes-foundation/bitsandbytes)
 - [GemLite](https://github.com/mobiusml/gemlite)
+- [Torchvision](https://github.com/pytorch/vision)
 - [vLLM](https://github.com/vllm-project/vllm)
 
 ## License

--- a/benchmarks/nms_benchmark.py
+++ b/benchmarks/nms_benchmark.py
@@ -200,7 +200,7 @@ def main(
             scores,
             iou_threshold,
         ),
-        tag="PyTorch Reference",
+        tag="Baseline",
         metadata=metadata,
         iteration_time_ms=iteration_time_ms,
         warmup_time_ms=warmup_time_ms,

--- a/benchmarks/nms_benchmark.py
+++ b/benchmarks/nms_benchmark.py
@@ -46,7 +46,7 @@ def _create_tensors_with_iou(num_boxes: int, iou_thresh: float) -> tuple[torch.T
     "--iou-threshold",
     required=False,
     type=float,
-    default=0.2,
+    default=0.5,
     help="IoU threshold for boxes to be kept",
 )
 @click.option(

--- a/benchmarks/nms_benchmark.py
+++ b/benchmarks/nms_benchmark.py
@@ -1,0 +1,308 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+"""NMS benchmark."""
+
+import sys
+from typing import Final
+
+import click
+import torch
+
+from conch.ops.vision.nms import nms as nms_conch
+from conch.platforms import current_platform
+from conch.reference.vision.nms import nms as nms_ref
+from conch.third_party.vllm.utils import seed_everything
+from conch.utils.benchmark import BenchmarkMetadata, benchmark_it
+
+
+def _create_tensors_with_iou(num_boxes: int, iou_thresh: float) -> tuple[torch.Tensor, torch.Tensor]:
+    # force last box to have a pre-defined iou with the first box
+    # let b0 be [x0, y0, x1, y1], and b1 be [x0, y0, x1 + d, y1],
+    # then, in order to satisfy ops.iou(b0, b1) == iou_thresh,
+    # we need to have d = (x1 - x0) * (1 - iou_thresh) / iou_thresh
+    # Adjust the threshold upward a bit with the intent of creating
+    # at least one box that exceeds (barely) the threshold and so
+    # should be suppressed.
+    boxes = torch.rand(num_boxes, 4) * 100
+    boxes[:, 2:] += boxes[:, :2]
+    boxes[-1, :] = boxes[0, :]
+    x0, y0, x1, y1 = boxes[-1].tolist()
+    iou_thresh += 1e-5
+    boxes[-1, 2] += (x1 - x0) * (1 - iou_thresh) / iou_thresh
+    scores = torch.rand(num_boxes)
+    return boxes, scores
+
+
+@click.command()
+@click.option(
+    "--num-boxes",
+    required=False,
+    type=int,
+    default=1000,
+    help="Number of boxes to create",
+)
+@click.option(
+    "--iou-threshold",
+    required=False,
+    type=float,
+    default=0.2,
+    help="IoU threshold for boxes to be kept",
+)
+@click.option(
+    "--vectorize-ref",
+    is_flag=True,
+    help="Flag to enable vectorization in the reference implementation",
+)
+@click.option(
+    "--gpu-ref",
+    is_flag=True,
+    help="Flag to enable GPU reference implementation",
+)
+@click.option(
+    "--iteration-time-ms",
+    required=False,
+    type=int,
+    default=10000,
+    help="Time in milliseconds to run benchmark",
+)
+@click.option(
+    "--warmup-time-ms",
+    required=False,
+    type=int,
+    default=1000,
+    help="Time in milliseconds to warmup before recording times",
+)
+@click.option(
+    "--absolute-tolerance",
+    required=False,
+    type=float,
+    default=1e-3,
+    help="Absolute tolerance to match with",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Flag for printing verbose output",
+)
+@click.option(
+    "--gpu",
+    required=False,
+    type=str,
+    default=current_platform.device,
+    help="Device to run on",
+)
+@click.option(
+    "--csv",
+    is_flag=True,
+    help="Flag for printing results in CSV format",
+)
+@click.option(
+    "--compile-ref",
+    is_flag=True,
+    help="Flag to torch.compile() the reference impl",
+)
+@click.option(
+    "--compile-conch",
+    is_flag=True,
+    help="Flag to torch.compile() the Conch impl",
+)
+def main(
+    num_boxes: int,
+    iou_threshold: float,
+    vectorize_ref: bool,
+    gpu_ref: bool,
+    iteration_time_ms: int,
+    warmup_time_ms: int,
+    absolute_tolerance: float,
+    verbose: bool,
+    gpu: str,
+    csv: bool,
+    compile_ref: bool,
+    compile_conch: bool,
+) -> None:
+    """Benchmark NMS.
+
+    Args:
+        num_boxes: Number of boxes to create.
+        iou_threshold: IoU threshold for boxes to be kept.
+        vectorize_ref: Flag to enable vectorization in the reference implementation.
+        gpu_ref: Flag to enable GPU reference implementation.
+        iteration_time_ms: Time in milliseconds to run benchmark.
+        warmup_time_ms: Time in milliseconds to warmup before recording times.
+        absolute_tolerance: Absolute tolerance used to check accuracy.
+        verbose: Flag to indicate whether or not to print verbose output.
+        gpu: Which gpu to run on.
+        csv: Flag to indicate whether or not to print results in CSV format.
+        compile_ref: Flag to torch.compile() the reference implementation.
+        compile_conch: Flag to torch.compile() the Conch implementation.
+    """
+    seed: Final = 0
+    seed_everything(seed)
+
+    device: Final = torch.device(gpu)
+    torch.set_default_device(device)
+
+    metadata = BenchmarkMetadata(
+        platform=current_platform.name(),
+        params={
+            "num_boxes": num_boxes,
+            "iou_threshold": iou_threshold,
+        },
+    )
+
+    boxes, scores = _create_tensors_with_iou(num_boxes, iou_threshold)
+
+    reference_vectorized_fn = None
+    reference_gpu_fn = None
+    if vectorize_ref:
+        # Use vectorized reference implementation if requested
+        from conch.reference.vision.nms import _nms_pytorch_vectorized
+
+        reference_vectorized_fn = _nms_pytorch_vectorized
+    if gpu_ref:
+        # Use GPU reference implementation if requested
+        from torchvision.ops.boxes import nms as nms_torchvision  # type: ignore[import-untyped]
+
+        reference_gpu_fn = nms_torchvision
+
+    reference_compiled_fn = None
+    reference_vectorized_compiled_fn = None
+    if compile_ref:
+        # Compile the reference implementation if requested
+        reference_compiled_fn = torch.compile(nms_ref)
+        if vectorize_ref:
+            reference_vectorized_compiled_fn = torch.compile(reference_vectorized_fn)
+
+    conch_compiled_fn = torch.compile(nms_conch) if compile_conch else None
+
+    # Get reference output
+    reference_output = nms_ref(boxes, scores, iou_threshold)
+
+    # Test Conch implementation
+    conch_output = nms_conch(boxes, scores, iou_threshold)
+
+    # Accuracy checks
+    if not torch.allclose(conch_output, reference_output, atol=absolute_tolerance):
+        print(f"WARNING: Reference and Conch results differ! (atol={absolute_tolerance})", file=sys.stderr)
+        print(f"Ref kept: {len(reference_output)}, Conch kept: {len(conch_output)}", file=sys.stderr)
+
+        if verbose:
+            print(f"Reference output: {reference_output}", file=sys.stderr)
+            print(f"Conch output: {conch_output}", file=sys.stderr)
+    else:
+        print(f"Reference vs Conch: Results matched with atol={absolute_tolerance} :)", file=sys.stderr)
+
+    # Benchmark implementations
+    baseline_result = benchmark_it(
+        lambda: nms_ref(
+            boxes,
+            scores,
+            iou_threshold,
+        ),
+        tag="PyTorch Reference",
+        metadata=metadata,
+        iteration_time_ms=iteration_time_ms,
+        warmup_time_ms=warmup_time_ms,
+    )
+
+    conch_result = benchmark_it(
+        lambda: nms_conch(
+            boxes,
+            scores,
+            iou_threshold,
+        ),
+        tag="Conch",
+        metadata=metadata,
+        iteration_time_ms=iteration_time_ms,
+        warmup_time_ms=warmup_time_ms,
+    )
+
+    reference_compiled_result = None
+    reference_vectorized_result = None
+    reference_vectorized_compiled_result = None
+    reference_gpu_result = None
+    conch_compiled_result = None
+
+    if reference_compiled_fn:
+        reference_compiled_result = benchmark_it(
+            lambda: reference_compiled_fn(
+                boxes,
+                scores,
+                iou_threshold,
+            ),
+            tag="PyTorch Reference (Compiled)",
+            metadata=metadata,
+            iteration_time_ms=iteration_time_ms,
+            warmup_time_ms=warmup_time_ms,
+        )
+
+    if reference_vectorized_fn:
+        reference_vectorized_result = benchmark_it(
+            lambda: reference_vectorized_fn(
+                boxes,
+                scores,
+                iou_threshold,
+            ),
+            tag="PyTorch Reference (Vectorized)",
+            metadata=metadata,
+            iteration_time_ms=iteration_time_ms,
+            warmup_time_ms=warmup_time_ms,
+        )
+
+    if reference_vectorized_compiled_fn:
+        reference_vectorized_compiled_result = benchmark_it(
+            lambda: reference_vectorized_compiled_fn(  # type: ignore[call-arg]
+                boxes,  # type: ignore[arg-type]
+                scores,
+                iou_threshold,
+            ),
+            tag="PyTorch Reference (Vectorized, Compiled)",
+            metadata=metadata,
+            iteration_time_ms=iteration_time_ms,
+            warmup_time_ms=warmup_time_ms,
+        )
+
+    if reference_gpu_fn:
+        reference_gpu_result = benchmark_it(
+            lambda: reference_gpu_fn(
+                boxes,
+                scores,
+                iou_threshold,
+            ),
+            tag="PyTorch GPU Reference",
+            metadata=metadata,
+            iteration_time_ms=iteration_time_ms,
+            warmup_time_ms=warmup_time_ms,
+        )
+
+    if conch_compiled_fn:
+        conch_compiled_result = benchmark_it(
+            lambda: conch_compiled_fn(
+                boxes,
+                scores,
+                iou_threshold,
+            ),
+            tag="Conch (Compiled)",
+            metadata=metadata,
+            iteration_time_ms=iteration_time_ms,
+            warmup_time_ms=warmup_time_ms,
+        )
+
+    conch_result.print_parameters(csv=csv)
+    conch_result.print_results(csv=csv)
+    baseline_result.print_results(csv=csv)
+    if reference_compiled_result:
+        reference_compiled_result.print_results(csv=csv)
+    if reference_vectorized_result:
+        reference_vectorized_result.print_results(csv=csv)
+    if reference_vectorized_compiled_result:
+        reference_vectorized_compiled_result.print_results(csv=csv)
+    if reference_gpu_result:
+        reference_gpu_result.print_results(csv=csv)
+    if conch_compiled_result:
+        conch_compiled_result.print_results(csv=csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/conch/README.md
+++ b/conch/README.md
@@ -8,4 +8,5 @@ Here is a running directory of the various envrionment variables:
 | ---| ---| ---|
 | `CONCH_BENCH_ENABLE_ALL_REF` | `1` or `true` (case in-sensitive) | Toggles whether or not to use bitsandbytes/vLLM reference implementations for benchmarking. |
 | `CONCH_ENABLE_BNB` | `1` or `true` (case in-sensitive) | Toggles whether or not to use bitsandbytes reference implementations. |
+| `CONCH_ENABLE_TORCHVISION` | `1` or `true` (case in-sensitive) | Toggles whether or not to use torchvision reference implementations. |
 | `CONCH_ENABLE_VLLM` | `1` or `true` (case in-sensitive) | Toggles whether or not to use vLLM reference implementations. |

--- a/conch/envs.py
+++ b/conch/envs.py
@@ -20,6 +20,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Enable bitsandbytes kernels for testing/benchmarking
     "CONCH_ENABLE_BNB": lambda: (os.environ.get("CONCH_ENABLE_BNB", "0").strip().lower() in ("1", "true")),
+    # Enable torchvision kernels for testing/benchmarking
+    "CONCH_ENABLE_TORCHVISION": lambda: (
+        os.environ.get("CONCH_ENABLE_TORCHVISION", "0").strip().lower() in ("1", "true")
+    ),
     # Enable vLLM kernels for testing/benchmarking
     "CONCH_ENABLE_VLLM": lambda: (os.environ.get("CONCH_ENABLE_VLLM", "0").strip().lower() in ("1", "true")),
 }

--- a/conch/kernels/vision/nms.py
+++ b/conch/kernels/vision/nms.py
@@ -206,9 +206,11 @@ def _nms_suppression_kernel(
                 # Conditionally store suppression result for high-IoU boxes
                 tl.store(keep_mask_ptr + target_box_offsets, False, mask=suppression_mask)
 
-                # Potential race condition: we need to ensure all threads complete the store before the next
-                # iteration otherwise we may load stale data for whether or not a box has been suppressed.
-                tl.debug_barrier()
+            # Potential race condition: we need to ensure all threads complete the store before the next
+            # iteration otherwise we may load stale data for whether or not a box has been suppressed.
+            # Aside: `debug_barrier` is a poor name for this function, because it is not only used for debugging,
+            # but also to ensure synchronization between threads.
+            tl.debug_barrier()
 
 
 def nms_launcher(

--- a/conch/kernels/vision/nms.py
+++ b/conch/kernels/vision/nms.py
@@ -1,0 +1,230 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Triton implementation of Non-Maximum Suppression (NMS).
+
+Kernel based on CUDA torchvision NMS implementation:
+https://github.com/pytorch/vision/blob/0721867e42841171254c7acaa45fbaf8ee16d3d7/torchvision/csrc/ops/cuda/nms_kernel.cu
+"""
+
+from typing import Any
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.autotune(  # type: ignore[misc]
+    configs=[
+        triton.Config({"cxpr_block_size": 64}),
+        triton.Config({"cxpr_block_size": 128}),
+        triton.Config({"cxpr_block_size": 256}),
+        triton.Config({"cxpr_block_size": 512}),
+        triton.Config({"cxpr_block_size": 1024}),
+    ],
+    key=["num_boxes"],
+)
+@triton.jit  # type: ignore[misc]
+def _calculate_iou_kernel(
+    # Tensors
+    boxes_ptr: tl.tensor,  # [N, 4]
+    iou_matrix_ptr: tl.tensor,  # [N, N]
+    # Scalars
+    num_boxes: int,
+    # Strides
+    boxes_stride: int,
+    iou_matrix_stride: int,
+    # Constexprs
+    cxpr_block_size: tl.constexpr,
+) -> None:
+    """Calculate IoU matrix between all pairs of boxes.
+
+    Args:
+        boxes_ptr: Pointer to boxes tensor, shape: (N, 4) in (x1, y1, x2, y2) format.
+        iou_matrix_ptr: Pointer to IoU matrix tensor, shape: (N, N).
+        num_boxes: Number of boxes.
+        boxes_stride: Stride for boxes tensor.
+        iou_matrix_stride: Stride for IoU matrix tensor.
+        cxpr_block_size: Block size for processing.
+    """
+    row_idx = tl.program_id(0)
+    col_block_start = tl.program_id(1) * cxpr_block_size
+
+    # Load the reference box (row_idx)
+    box1_offset = row_idx * boxes_stride
+    box1_x1 = tl.load(boxes_ptr + box1_offset + 0)
+    box1_y1 = tl.load(boxes_ptr + box1_offset + 1)
+    box1_x2 = tl.load(boxes_ptr + box1_offset + 2)
+    box1_y2 = tl.load(boxes_ptr + box1_offset + 3)
+
+    box1_area = (box1_x2 - box1_x1) * (box1_y2 - box1_y1)
+
+    # Process a block of columns
+    col_offsets = col_block_start + tl.arange(0, cxpr_block_size)
+    col_mask = col_offsets < num_boxes
+
+    # Load boxes in the current block
+    box2_offsets = col_offsets * boxes_stride
+    box2_x1 = tl.load(boxes_ptr + box2_offsets + 0, mask=col_mask)
+    box2_y1 = tl.load(boxes_ptr + box2_offsets + 1, mask=col_mask)
+    box2_x2 = tl.load(boxes_ptr + box2_offsets + 2, mask=col_mask)
+    box2_y2 = tl.load(boxes_ptr + box2_offsets + 3, mask=col_mask)
+
+    box2_area = (box2_x2 - box2_x1) * (box2_y2 - box2_y1)
+
+    # Calculate intersection
+    inter_x1 = tl.maximum(box1_x1, box2_x1)
+    inter_y1 = tl.maximum(box1_y1, box2_y1)
+    inter_x2 = tl.minimum(box1_x2, box2_x2)
+    inter_y2 = tl.minimum(box1_y2, box2_y2)
+
+    # Check if there's valid intersection
+    inter_w = tl.maximum(0.0, inter_x2 - inter_x1)
+    inter_h = tl.maximum(0.0, inter_y2 - inter_y1)
+    inter_area = inter_w * inter_h
+
+    # Calculate union and IoU
+    union_area = box1_area + box2_area - inter_area
+    iou = tl.where(union_area > 0.0, inter_area / union_area, 0.0)
+
+    # Store IoU values
+    iou_output_offsets = row_idx * iou_matrix_stride + col_offsets
+    tl.store(iou_matrix_ptr + iou_output_offsets, iou, mask=col_mask)
+
+
+@triton.autotune(  # type: ignore[misc]
+    configs=[
+        triton.Config({"cxpr_block_size": 64}),
+        triton.Config({"cxpr_block_size": 128}),
+        triton.Config({"cxpr_block_size": 256}),
+        triton.Config({"cxpr_block_size": 512}),
+        triton.Config({"cxpr_block_size": 1024}),
+    ],
+    key=["num_boxes"],
+)
+@triton.jit  # type: ignore[misc]
+def _nms_suppression_kernel(
+    # Tensors
+    sorted_indices_ptr: tl.tensor,  # [N]
+    iou_matrix_ptr: tl.tensor,  # [N, N]
+    keep_mask_ptr: tl.tensor,  # [N]
+    # Scalars
+    num_boxes: int,
+    iou_threshold: float,
+    # Strides
+    iou_matrix_stride: int,
+    # Constexprs
+    cxpr_block_size: tl.constexpr,
+    cxpr_num_boxes_padded: tl.constexpr,
+) -> None:
+    """NMS suppression kernel.
+
+    Args:
+        sorted_indices_ptr: Pointer to sorted indices tensor, shape: (N,).
+        iou_matrix_ptr: Pointer to precomputed IoU matrix, shape: (N, N).
+        keep_mask_ptr: Pointer to keep mask tensor, shape: (N,).
+        num_boxes: Number of boxes.
+        iou_threshold: IoU threshold for suppression.
+        iou_matrix_stride: Stride for IoU matrix tensor.
+        cxpr_block_size: Block size for processing.
+        cxpr_num_boxes_padded: Padded number of boxes for block processing.
+    """
+    # Sequential NMS: for each box in sorted order, suppress later boxes
+    # Iterate through sorted indices
+    for i in range(num_boxes):
+        # Get the current box index from sorted indices
+        current_box_idx = tl.load(sorted_indices_ptr + i)
+
+        # Check if current box is still kept
+        is_kept = tl.load(keep_mask_ptr + current_box_idx)
+        if is_kept:
+            # IoU row offset for the current box
+            iou_row_offset = current_box_idx * iou_matrix_stride
+
+            # Iterate blockwise through the columns
+            for block_idx in range(triton.cdiv(cxpr_num_boxes_padded, cxpr_block_size)):
+                # Only need to consider later boxes, so start from i + 1 (i is the current box index)
+                block_start = i + 1 + block_idx * cxpr_block_size
+                # Only process if the start of the block is within bounds
+                if block_start < num_boxes:
+                    # Masked load of indices for the target boxes in the current block
+                    target_box_offsets = block_start + tl.arange(0, cxpr_block_size)
+                    target_box_mask = target_box_offsets < num_boxes
+                    target_box_indices = tl.load(sorted_indices_ptr + target_box_offsets, mask=target_box_mask)
+
+                    # Load IoU values for the current block
+                    iou_values = tl.load(iou_matrix_ptr + iou_row_offset + target_box_indices, mask=target_box_mask)
+
+                    # Suppress boxes with lower scores that have high IoU
+                    suppression_mask = tl.where(iou_values > iou_threshold, True, False)
+
+                    # Conditionally store suppression result for high-IoU boxes
+                    tl.store(keep_mask_ptr + target_box_indices, False, mask=suppression_mask)
+
+
+def nms_launcher(
+    boxes: torch.Tensor,
+    scores: torch.Tensor,
+    iou_matrix: torch.Tensor,
+    keep_mask: torch.Tensor,
+    iou_threshold: float,
+) -> torch.Tensor:
+    """Launch NMS kernel.
+
+    Args:
+        boxes: Boxes tensor of shape (N, 4) in (x1, y1, x2, y2) format.
+        scores: Scores tensor of shape (N,).
+        iou_matrix: IoU matrix of shape (N, N).
+        keep_mask: Mask tensor of shape (N,) indicating which boxes are kept.
+        iou_threshold: IoU threshold for suppression.
+
+    Returns:
+        Tensor: Indices of kept boxes, sorted by decreasing score.
+    """
+    assert boxes.dim() == 2 and boxes.size(1) == 4, "Boxes must have shape (N, 4)"
+    assert scores.dim() == 1, "Scores must be 1D"
+    assert boxes.size(0) == scores.size(0), "Number of boxes and scores must match"
+    assert boxes.is_contiguous(), "Boxes tensor must be contiguous"
+    assert scores.is_contiguous(), "Scores tensor must be contiguous"
+
+    num_boxes = boxes.size(0)
+
+    # Sort boxes by scores in descending order
+    sorted_scores, sorted_indices = torch.sort(scores, descending=True)
+
+    # Calculate IoU of each each block against all other boxes in parallel. Process other boxes
+    # blockwise in chunks of size `cxpr_block_size`.
+    def stage1_grid(meta: dict[str, Any]) -> tuple[int, int]:
+        return (num_boxes, triton.cdiv(num_boxes, meta["cxpr_block_size"]))
+
+    # Calculate IoU matrix using Triton kernel
+    _calculate_iou_kernel[stage1_grid](
+        # Tensors
+        boxes_ptr=boxes,
+        iou_matrix_ptr=iou_matrix,
+        # Scalars
+        num_boxes=num_boxes,
+        # Strides
+        boxes_stride=boxes.stride(0),
+        iou_matrix_stride=iou_matrix.stride(0),
+    )
+
+    # For the suppression stage, we need to process sequentially, but we'll still take
+    # advantage of parallelism by processing in blocks in one program.
+    stage2_grid = (1,)
+    _nms_suppression_kernel[stage2_grid](
+        # Tensors
+        sorted_indices_ptr=sorted_indices,
+        iou_matrix_ptr=iou_matrix,
+        keep_mask_ptr=keep_mask,
+        # Scalars
+        num_boxes=num_boxes,
+        iou_threshold=iou_threshold,
+        # Strides
+        iou_matrix_stride=iou_matrix.stride(0),
+        # Constexprs
+        cxpr_num_boxes_padded=triton.next_power_of_2(num_boxes),
+    )
+
+    # Extract indices of kept boxes
+    return sorted_indices[keep_mask[sorted_indices]]

--- a/conch/ops/vision/nms.py
+++ b/conch/ops/vision/nms.py
@@ -14,13 +14,13 @@ def nms(boxes: torch.Tensor, scores: torch.Tensor, iou_threshold: float) -> torc
     to their intersection-over-union (IoU).
 
     NMS iteratively removes lower scoring boxes which have an
-    IoU greater than ``iou_threshold`` with another (higher scoring)
+    IoU greater than `iou_threshold` with another (higher scoring)
     box.
 
     Args:
         boxes (Tensor[N, 4])): boxes to perform NMS on. They
-            are expected to be in ``(x1, y1, x2, y2)`` format with ``0 <= x1 < x2`` and
-            ``0 <= y1 < y2``.
+            are expected to be in `(x1, y1, x2, y2)` format with `0 <= x1 < x2` and
+            `0 <= y1 < y2`.
         scores (Tensor[N]): scores for each one of the boxes
         iou_threshold (float): discards all overlapping boxes with IoU > iou_threshold
 
@@ -34,8 +34,10 @@ def nms(boxes: torch.Tensor, scores: torch.Tensor, iou_threshold: float) -> torc
     if num_boxes == 0:
         return torch.empty(0, dtype=torch.long, device=device)
 
-    # Storage for pre-computation of IoU matrix
-    iou_matrix = torch.zeros((num_boxes, num_boxes), dtype=boxes.dtype, device=device)
+    # Storage for pre-computation of IoU mask
+    # This is a boolean matrix indicating whether the IoU between two boxes exceeds the threshold.
+    iou_mask = torch.empty((num_boxes, num_boxes), dtype=torch.bool, device=device)
+    iou_mask.fill_(False)
 
     # Initialize keep mask - all boxes are initially kept
     keep_mask = torch.empty(num_boxes, dtype=torch.bool, device=device)
@@ -44,7 +46,7 @@ def nms(boxes: torch.Tensor, scores: torch.Tensor, iou_threshold: float) -> torc
     return nms_launcher(
         boxes=boxes,
         scores=scores,
-        iou_matrix=iou_matrix,
+        iou_mask=iou_mask,
         keep_mask=keep_mask,
         iou_threshold=iou_threshold,
     )

--- a/conch/ops/vision/nms.py
+++ b/conch/ops/vision/nms.py
@@ -1,0 +1,50 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Non-Maximum Suppression (NMS) operation."""
+
+import torch
+
+from conch.kernels.vision.nms import nms_launcher
+
+
+def nms(boxes: torch.Tensor, scores: torch.Tensor, iou_threshold: float) -> torch.Tensor:
+    """
+    Performs non-maximum suppression (NMS) on the boxes according
+    to their intersection-over-union (IoU).
+
+    NMS iteratively removes lower scoring boxes which have an
+    IoU greater than ``iou_threshold`` with another (higher scoring)
+    box.
+
+    Args:
+        boxes (Tensor[N, 4])): boxes to perform NMS on. They
+            are expected to be in ``(x1, y1, x2, y2)`` format with ``0 <= x1 < x2`` and
+            ``0 <= y1 < y2``.
+        scores (Tensor[N]): scores for each one of the boxes
+        iou_threshold (float): discards all overlapping boxes with IoU > iou_threshold
+
+    Returns:
+        Tensor: int64 tensor with the indices of the elements that have been kept
+        by NMS, sorted in decreasing order of scores
+    """
+    num_boxes = boxes.size(0)
+    device = boxes.device
+
+    if num_boxes == 0:
+        return torch.empty(0, dtype=torch.long, device=device)
+
+    # Storage for pre-computation of IoU matrix
+    iou_matrix = torch.zeros((num_boxes, num_boxes), dtype=boxes.dtype, device=device)
+
+    # Initialize keep mask - all boxes are initially kept
+    keep_mask = torch.empty(num_boxes, dtype=torch.bool, device=device)
+    keep_mask.fill_(True)
+
+    return nms_launcher(
+        boxes=boxes,
+        scores=scores,
+        iou_matrix=iou_matrix,
+        keep_mask=keep_mask,
+        iou_threshold=iou_threshold,
+    )

--- a/conch/reference/vision/nms.py
+++ b/conch/reference/vision/nms.py
@@ -1,0 +1,195 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+"""PyTorch reference implementation of non-max suppression."""
+
+import torch
+
+from conch import envs
+
+
+def _calculate_iou(boxes1: torch.Tensor, boxes2: torch.Tensor) -> torch.Tensor:
+    """Calculate IoU between two sets of boxes.
+
+    Args:
+        boxes1: Tensor of shape (N, 4) in (x1, y1, x2, y2) format.
+        boxes2: Tensor of shape (M, 4) in (x1, y1, x2, y2) format.
+
+    Returns:
+        Tensor of shape (N, M) containing IoU values.
+    """
+    # Calculate areas
+    area1 = (boxes1[:, 2] - boxes1[:, 0]) * (boxes1[:, 3] - boxes1[:, 1])  # (N,)
+    area2 = (boxes2[:, 2] - boxes2[:, 0]) * (boxes2[:, 3] - boxes2[:, 1])  # (M,)
+
+    # Expand dimensions for broadcasting
+    boxes1_expanded = boxes1.unsqueeze(1)  # (N, 1, 4)
+    boxes2_expanded = boxes2.unsqueeze(0)  # (1, M, 4)
+
+    # Calculate intersection coordinates
+    inter_x1 = torch.max(boxes1_expanded[:, :, 0], boxes2_expanded[:, :, 0])  # (N, M)
+    inter_y1 = torch.max(boxes1_expanded[:, :, 1], boxes2_expanded[:, :, 1])  # (N, M)
+    inter_x2 = torch.min(boxes1_expanded[:, :, 2], boxes2_expanded[:, :, 2])  # (N, M)
+    inter_y2 = torch.min(boxes1_expanded[:, :, 3], boxes2_expanded[:, :, 3])  # (N, M)
+
+    # Calculate intersection area
+    inter_w = torch.clamp(inter_x2 - inter_x1, min=0.0)
+    inter_h = torch.clamp(inter_y2 - inter_y1, min=0.0)
+    inter_area = inter_w * inter_h  # (N, M)
+
+    # Calculate union area
+    area1_expanded = area1.unsqueeze(1)  # (N, 1)
+    area2_expanded = area2.unsqueeze(0)  # (1, M)
+    union_area = area1_expanded + area2_expanded - inter_area  # (N, M)
+
+    # Calculate IoU
+    iou = inter_area / torch.clamp(union_area, min=1e-6)
+
+    return iou
+
+
+def _nms_pytorch_iterative(boxes: torch.Tensor, scores: torch.Tensor, iou_threshold: float) -> torch.Tensor:
+    """
+    Performs non-maximum suppression (NMS) on the boxes according
+    to their intersection-over-union (IoU).
+
+    NMS iteratively removes lower scoring boxes which have an
+    IoU greater than ``iou_threshold`` with another (higher scoring)
+    box.
+
+    If multiple boxes have the exact same score and satisfy the IoU
+    criterion with respect to a reference box, the selected box is
+    not guaranteed to be the same between CPU and GPU. This is similar
+    to the behavior of argsort in PyTorch when repeated values are present.
+
+    Args:
+        boxes (Tensor[N, 4])): boxes to perform NMS on. They
+            are expected to be in ``(x1, y1, x2, y2)`` format with ``0 <= x1 < x2`` and
+            ``0 <= y1 < y2``.
+        scores (Tensor[N]): scores for each one of the boxes
+        iou_threshold (float): discards all overlapping boxes with IoU > iou_threshold
+
+    Returns:
+        Tensor: int64 tensor with the indices of the elements that have been kept
+        by NMS, sorted in decreasing order of scores
+    """
+    if boxes.numel() == 0:
+        return torch.empty(0, dtype=torch.long, device=boxes.device)
+
+    # Sort boxes by scores in descending order
+    sorted_scores, sorted_indices = torch.sort(scores, descending=True)
+
+    # Keep track of which boxes to keep
+    keep = []
+
+    # Process boxes in order of decreasing score
+    while sorted_indices.numel() > 0:
+        # Take the box with highest score
+        current_idx = sorted_indices[0]
+        # keep.append(current_idx.item())
+        keep.append(current_idx)
+
+        if sorted_indices.numel() == 1:
+            break
+
+        # Get remaining boxes
+        remaining_indices = sorted_indices[1:]
+        current_box = boxes[current_idx].unsqueeze(0)  # (1, 4)
+        remaining_boxes = boxes[remaining_indices]  # (K, 4)
+
+        # Calculate IoU between current box and all remaining boxes
+        ious = _calculate_iou(current_box, remaining_boxes)  # (1, K)
+        ious = ious.squeeze(0)  # (K,)
+
+        # Keep only boxes with IoU below threshold
+        keep_mask = ious <= iou_threshold
+        sorted_indices = remaining_indices[keep_mask]
+
+    return torch.tensor(keep, dtype=torch.long, device=boxes.device)
+
+
+def _nms_pytorch_vectorized(boxes: torch.Tensor, scores: torch.Tensor, iou_threshold: float) -> torch.Tensor:
+    """
+    Vectorized implementation of NMS that pre-computes all IoUs.
+
+    This version is more memory-intensive but can be faster for medium-sized inputs
+    by reducing the number of iterations.
+
+    Args:
+        boxes (Tensor[N, 4])): boxes to perform NMS on. They
+            are expected to be in ``(x1, y1, x2, y2)`` format with ``0 <= x1 < x2`` and
+            ``0 <= y1 < y2``.
+        scores (Tensor[N]): scores for each one of the boxes
+        iou_threshold (float): discards all overlapping boxes with IoU > iou_threshold
+
+    Returns:
+        Tensor: int64 tensor with the indices of the elements that have been kept
+        by NMS, sorted in decreasing order of scores
+    """
+    if boxes.numel() == 0:
+        return torch.empty(0, dtype=torch.long, device=boxes.device)
+
+    num_boxes = boxes.size(0)
+
+    # Sort boxes by scores in descending order
+    sorted_scores, sorted_indices = torch.sort(scores, descending=True)
+
+    # Pre-compute all pairwise IoUs
+    iou_matrix = _calculate_iou(boxes, boxes)  # (N, N)
+
+    # Initialize keep mask
+    keep_mask = torch.ones(num_boxes, dtype=torch.bool, device=boxes.device)
+
+    # Process boxes in order of decreasing score
+    for i in range(num_boxes):
+        current_idx = sorted_indices[i]
+
+        if not keep_mask[current_idx]:
+            continue
+
+        # Suppress boxes with higher IoU than threshold
+        # Only consider boxes with lower scores (higher indices in sorted order)
+        for j in range(i + 1, num_boxes):
+            next_idx = sorted_indices[j]
+            if keep_mask[next_idx] and iou_matrix[current_idx, next_idx] > iou_threshold:
+                keep_mask[next_idx] = False
+
+    # Extract kept indices in original score order
+    return sorted_indices[keep_mask[sorted_indices]]
+
+
+def nms(boxes: torch.Tensor, scores: torch.Tensor, iou_threshold: float, vectorize: bool = False) -> torch.Tensor:
+    """
+    Performs non-maximum suppression (NMS) on the boxes according
+    to their intersection-over-union (IoU).
+
+    NMS iteratively removes lower scoring boxes which have an
+    IoU greater than ``iou_threshold`` with another (higher scoring)
+    box.
+
+    If multiple boxes have the exact same score and satisfy the IoU
+    criterion with respect to a reference box, the selected box is
+    not guaranteed to be the same between CPU and GPU. This is similar
+    to the behavior of argsort in PyTorch when repeated values are present.
+
+    Args:
+        boxes (Tensor[N, 4])): boxes to perform NMS on. They
+            are expected to be in ``(x1, y1, x2, y2)`` format with ``0 <= x1 < x2`` and
+            ``0 <= y1 < y2``.
+        scores (Tensor[N]): scores for each one of the boxes
+        iou_threshold (float): discards all overlapping boxes with IoU > iou_threshold
+        vectorize (bool): whether to enable vectorized NMS implementation
+
+    Returns:
+        Tensor: int64 tensor with the indices of the elements that have been kept
+        by NMS, sorted in decreasing order of scores
+    """
+    if envs.CONCH_ENABLE_TORCHVISION:
+        from torchvision.ops.boxes import nms as nms_torchvision  # type: ignore[import-untyped]
+
+        return nms_torchvision(boxes, scores, iou_threshold)  # type: ignore[no-any-return]
+
+    if vectorize:
+        return _nms_pytorch_vectorized(boxes, scores, iou_threshold)
+
+    return _nms_pytorch_iterative(boxes, scores, iou_threshold)

--- a/conch/reference/vision/nms.py
+++ b/conch/reference/vision/nms.py
@@ -77,7 +77,7 @@ def _nms_pytorch_iterative(boxes: torch.Tensor, scores: torch.Tensor, iou_thresh
         return torch.empty(0, dtype=torch.long, device=boxes.device)
 
     # Sort boxes by scores in descending order
-    sorted_scores, sorted_indices = torch.sort(scores, descending=True)
+    _, sorted_indices = torch.sort(scores, dim=0, stable=True, descending=True)
 
     # Keep track of which boxes to keep
     keep = []
@@ -132,7 +132,7 @@ def _nms_pytorch_vectorized(boxes: torch.Tensor, scores: torch.Tensor, iou_thres
     num_boxes = boxes.size(0)
 
     # Sort boxes by scores in descending order
-    sorted_scores, sorted_indices = torch.sort(scores, descending=True)
+    _, sorted_indices = torch.sort(scores, dim=0, stable=True, descending=True)
 
     # Pre-compute all pairwise IoUs
     iou_matrix = _calculate_iou(boxes, boxes)  # (N, N)

--- a/docs/getting_started/developer_environment.md
+++ b/docs/getting_started/developer_environment.md
@@ -95,3 +95,14 @@ In order to use them, you can install vLLM (`pip install vllm`) and set the envi
 pip install vllm==0.9.1
 CONCH_ENABLE_VLLM=1 python benchmarks/paged_attention_benchmark.py
 ```
+
+### Optional: Benchmarking against Torchvision
+
+Some unit tests/benchmarks allow comparison to CUDA implementations of operations from Torchvision (rather than PyTorch-reference implementations).
+In order to use them, you can install Torchvision (`pip install torchvision`) and set the environment variable `CONCH_ENABLE_TORCHVISION=1`.
+
+```bash
+# Note: add `--extra-index-url https://download.pytorch.org/whl/rocm6.2.4` on ROCm
+pip install torchvision==0.22
+CONCH_ENABLE_TORCHVISION=1 python benchmarks/nms_benchmark.py
+```

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ from typing import Final
 from setuptools import setup
 
 _TORCH_VERSION: Final = "2.7.0"
-_TORCHVISION_VERSION: Final = "0.22"
 _TRITON_VERSION: Final = "3.3.0"
 
 _REQUIREMENTS: Final = [
@@ -17,7 +16,6 @@ _REQUIREMENTS: Final = [
 # --extra-index-url https://download.pytorch.org/whl/cpu
 _DEFAULT_PLATFORM_REQUIREMENTS: Final = [
     f"torch=={_TORCH_VERSION}",
-    f"torchvision=={_TORCHVISION_VERSION}",
     f"triton>={_TRITON_VERSION}",
 ]
 
@@ -25,7 +23,6 @@ _DEFAULT_PLATFORM_REQUIREMENTS: Final = [
 # --extra-index-url https://download.pytorch.org/whl/rocm6.2.4
 _ROCM_PLATFORM_REQUIREMENTS: Final = [
     f"torch=={_TORCH_VERSION}+rocm6.2.4",
-    f"torchvision=={_TORCHVISION_VERSION}+rocm6.2.4",
     f"pytorch-triton-rocm>={_TRITON_VERSION}",
 ]
 
@@ -33,7 +30,6 @@ _ROCM_PLATFORM_REQUIREMENTS: Final = [
 # --extra-index-url https://download.pytorch.org/whl/xpu
 _XPU_PLATFORM_REQUIREMENTS: Final = [
     f"torch=={_TORCH_VERSION}+xpu",
-    f"torchvision=={_TORCHVISION_VERSION}+xpu",
     f"pytorch-triton-xpu>={_TRITON_VERSION}",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ _REQUIREMENTS: Final = [
 # --extra-index-url https://download.pytorch.org/whl/cpu
 _DEFAULT_PLATFORM_REQUIREMENTS: Final = [
     f"torch=={_TORCH_VERSION}",
+    "torchvision==0.22",
     "triton>=3.3.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,8 @@ from typing import Final
 from setuptools import setup
 
 _TORCH_VERSION: Final = "2.7.0"
+_TORCHVISION_VERSION: Final = "0.22"
+_TRITON_VERSION: Final = "3.3.0"
 
 _REQUIREMENTS: Final = [
     "numpy>=1.26.4",
@@ -15,22 +17,24 @@ _REQUIREMENTS: Final = [
 # --extra-index-url https://download.pytorch.org/whl/cpu
 _DEFAULT_PLATFORM_REQUIREMENTS: Final = [
     f"torch=={_TORCH_VERSION}",
-    "torchvision==0.22",
-    "triton>=3.3.0",
+    f"torchvision=={_TORCHVISION_VERSION}",
+    f"triton>={_TRITON_VERSION}",
 ]
 
 # For ROCm:
 # --extra-index-url https://download.pytorch.org/whl/rocm6.2.4
 _ROCM_PLATFORM_REQUIREMENTS: Final = [
     f"torch=={_TORCH_VERSION}+rocm6.2.4",
-    "pytorch-triton-rocm>=3.3.0",
+    f"torchvision=={_TORCHVISION_VERSION}+rocm6.2.4",
+    f"pytorch-triton-rocm>={_TRITON_VERSION}",
 ]
 
 # For XPU:
 # --extra-index-url https://download.pytorch.org/whl/xpu
 _XPU_PLATFORM_REQUIREMENTS: Final = [
     f"torch=={_TORCH_VERSION}+xpu",
-    "pytorch-triton-xpu>=3.3.0",
+    f"torchvision=={_TORCHVISION_VERSION}+xpu",
+    f"pytorch-triton-xpu>={_TRITON_VERSION}",
 ]
 
 _PLATFORM_REQUIREMENTS: Final = {

--- a/tests/nms_test.py
+++ b/tests/nms_test.py
@@ -34,7 +34,7 @@ def _create_tensors_with_iou(num_boxes: int, iou_thresh: float) -> tuple[torch.T
 
 @pytest.mark.parametrize("num_boxes", [10, 100, 1000, 4000])
 @pytest.mark.parametrize("iou_threshold", [0.2, 0.5, 0.8])
-@pytest.mark.parametrize("seed", range(3))
+@pytest.mark.parametrize("seed", range(10))
 def test_nms_conch_vs_reference(
     num_boxes: int,
     iou_threshold: float,

--- a/tests/nms_test.py
+++ b/tests/nms_test.py
@@ -52,6 +52,9 @@ def test_nms_conch_vs_reference(
     keep_ref = nms_ref(boxes, scores, iou_threshold)
     keep_conch = nms_conch(boxes, scores, iou_threshold)
 
+    print(f"{keep_conch=}")
+    print(f"{keep_ref=}")
+
     # Results should be identical (same indices, same order)
     torch.testing.assert_close(keep_ref, keep_conch)
 

--- a/tests/nms_test.py
+++ b/tests/nms_test.py
@@ -1,0 +1,144 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test non-max suppression."""
+
+from typing import Final
+
+import pytest
+import torch
+
+from conch.ops.vision.nms import nms as nms_conch
+from conch.platforms import current_platform
+from conch.reference.vision.nms import nms as nms_ref
+from conch.third_party.vllm.utils import seed_everything
+
+
+def _create_tensors_with_iou(num_boxes: int, iou_thresh: float) -> tuple[torch.Tensor, torch.Tensor]:
+    # force last box to have a pre-defined iou with the first box
+    # let b0 be [x0, y0, x1, y1], and b1 be [x0, y0, x1 + d, y1],
+    # then, in order to satisfy ops.iou(b0, b1) == iou_thresh,
+    # we need to have d = (x1 - x0) * (1 - iou_thresh) / iou_thresh
+    # Adjust the threshold upward a bit with the intent of creating
+    # at least one box that exceeds (barely) the threshold and so
+    # should be suppressed.
+    boxes = torch.rand(num_boxes, 4) * 100
+    boxes[:, 2:] += boxes[:, :2]
+    boxes[-1, :] = boxes[0, :]
+    x0, y0, x1, y1 = boxes[-1].tolist()
+    iou_thresh += 1e-5
+    boxes[-1, 2] += (x1 - x0) * (1 - iou_thresh) / iou_thresh
+    scores = torch.rand(num_boxes)
+    return boxes, scores
+
+
+@pytest.mark.parametrize("num_boxes", [10, 100, 1000, 4000])
+@pytest.mark.parametrize("iou_threshold", [0.2, 0.5, 0.8])
+@pytest.mark.parametrize("seed", range(3))
+def test_nms_conch_vs_reference(
+    num_boxes: int,
+    iou_threshold: float,
+    seed: int,
+) -> None:
+    """Test that Triton NMS gives same results as reference implementation."""
+    seed_everything(seed)
+
+    device: Final = torch.device(current_platform.device)
+    torch.set_default_device(device)
+
+    boxes, scores = _create_tensors_with_iou(num_boxes, iou_threshold)
+
+    # Get results from both implementations
+    keep_ref = nms_ref(boxes, scores, iou_threshold)
+    keep_conch = nms_conch(boxes, scores, iou_threshold)
+
+    # Results should be identical (same indices, same order)
+    torch.testing.assert_close(keep_ref, keep_conch)
+
+
+def test_nms_edge_cases() -> None:
+    """Test NMS edge cases."""
+    device: Final = torch.device(current_platform.device)
+    torch.set_default_device(device)
+
+    # Test empty input
+    empty_boxes = torch.empty(0, 4, device=device)
+    empty_scores = torch.empty(0, device=device)
+
+    keep_ref = nms_ref(empty_boxes, empty_scores, 0.5)
+    keep_conch = nms_conch(empty_boxes, empty_scores, 0.5)
+
+    assert len(keep_ref) == 0
+    assert len(keep_conch) == 0
+
+    # Test single box
+    single_box = torch.tensor([[0.0, 0.0, 10.0, 10.0]], device=device)
+    single_score = torch.tensor([0.9], device=device)
+
+    keep_ref = nms_ref(single_box, single_score, 0.5)
+    keep_conch = nms_conch(single_box, single_score, 0.5)
+
+    torch.testing.assert_close(keep_ref, keep_conch)
+    assert len(keep_ref) == 1
+    assert len(keep_conch) == 1
+
+
+@pytest.mark.parametrize("iou_threshold", [0.0, 0.3, 0.7, 1.0])
+def test_nms_identical_boxes(iou_threshold: float) -> None:
+    """Test NMS with identical boxes at different score levels."""
+    device: Final = torch.device(current_platform.device)
+    torch.set_default_device(device)
+
+    # Create multiple identical boxes with different scores
+    boxes = torch.tensor(
+        [
+            [0.0, 0.0, 10.0, 10.0],
+            [0.0, 0.0, 10.0, 10.0],
+            [0.0, 0.0, 10.0, 10.0],
+            [0.0, 0.0, 10.0, 10.0],
+        ],
+        device=device,
+    )
+
+    scores = torch.tensor([0.9, 0.8, 0.7, 0.6], device=device)
+
+    keep_ref = nms_ref(boxes, scores, iou_threshold)
+    keep_conch = nms_conch(boxes, scores, iou_threshold)
+
+    # For identical boxes, only the highest scoring one should be kept (except when threshold is 1.0)
+    if iou_threshold < 1.0:
+        assert len(keep_ref) == 1
+        assert len(keep_conch) == 1
+        assert keep_ref[0] == 0  # Highest scoring box
+        assert keep_conch[0] == 0
+    else:
+        # When threshold is 1.0, all boxes should be kept
+        assert len(keep_ref) == boxes.size(0)
+        assert len(keep_conch) == boxes.size(0)
+
+
+def test_nms_no_overlap() -> None:
+    """Test NMS with non-overlapping boxes."""
+    device: Final = torch.device(current_platform.device)
+    torch.set_default_device(device)
+
+    # Create non-overlapping boxes
+    boxes = torch.tensor(
+        [
+            [0.0, 0.0, 5.0, 5.0],
+            [10.0, 10.0, 15.0, 15.0],
+            [20.0, 20.0, 25.0, 25.0],
+            [30.0, 30.0, 35.0, 35.0],
+        ],
+        device=device,
+    )
+
+    scores = torch.tensor([0.9, 0.8, 0.7, 0.6], device=device)
+
+    keep_ref = nms_ref(boxes, scores, 0.5)
+    keep_conch = nms_conch(boxes, scores, 0.5)
+
+    # All boxes should be kept since they don't overlap
+    torch.testing.assert_close(keep_ref, keep_conch)
+    assert len(keep_ref) == boxes.size(0)
+    assert len(keep_conch) == boxes.size(0)

--- a/tools/benchmarks/collect_nms.sh
+++ b/tools/benchmarks/collect_nms.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+# Specify CONCH_ENABLE_TORCHVISION=1 to compare against torchvision gpu ref impl (if installed)
+# Specify CONCH_BENCH_NO_CSV=1 to print results to stdout instead of file
+
+# Create output directory
+benchmark_name="nms"
+benchmark_dir="results/$benchmark_name"
+mkdir -p $benchmark_dir
+
+num_boxes=(
+  "512"
+  "2048"
+  "8192"
+)
+
+for boxes in ${num_boxes[@]}; do
+  output_file="$benchmark_dir/$seq_len.csv"
+  csv_flag="--csv"
+
+  if [ -v CONCH_BENCH_NO_CSV ]; then
+    output_file=/dev/stdout
+    csv_flag=" "
+  fi
+
+  python benchmarks/nms_benchmark.py $csv_flag --num-boxes $boxes > $output_file
+done

--- a/tools/benchmarks/collect_nms.sh
+++ b/tools/benchmarks/collect_nms.sh
@@ -12,12 +12,15 @@ mkdir -p $benchmark_dir
 
 num_boxes=(
   "512"
+  "1024"
   "2048"
   "8192"
+  "16384"
+  "32768"
 )
 
 for boxes in ${num_boxes[@]}; do
-  output_file="$benchmark_dir/$seq_len.csv"
+  output_file="$benchmark_dir/$boxes.csv"
   csv_flag="--csv"
 
   if [ -v CONCH_BENCH_NO_CSV ]; then

--- a/tools/create_benchmark_results_table.py
+++ b/tools/create_benchmark_results_table.py
@@ -34,6 +34,7 @@ _TABLE_OP_NAME_TO_BENCHMARK: Final = {
     "Int8 Static Quantization": "static_scaled_int8_quant_benchmark",
     "Mixed-precision GEMM [Int4 x FP16]": "mixed_precision_gemm_benchmark",
     "Scaled GEMM [Int8 x BF16]": "scaled_gemm_benchmark",
+    "Non-Max Suppression": "nms_benchmark",
     "vLLM: Copy Blocks": "copy_blocks_benchmark",
     "vLLM: Reshape and Cache": "reshape_and_cache_benchmark",
 }
@@ -48,6 +49,10 @@ _DEVICE_SPECIFIC_BLACKLIST: Final = {
 
 # Add any extra flags for each benchmark here
 _EXTRA_BENCHMARK_FLAGS: Final = {
+    "gelu_tanh_and_mul_benchmark": ["--compile-ref"],
+    "silu_and_mul_benchmark": ["--compile-ref"],
+    "gemma_rms_norm_benchmark": ["--compile-ref"],
+    "rms_norm_benchmark": ["--compile-ref"],
     "varlen_attention_benchmark": ["--causal"],
 }
 
@@ -69,6 +74,7 @@ def main(results_directory: Path, use_cached_results: bool) -> None:
     # Always run against fastest possible implementation
     os.environ["CONCH_BENCH_ENABLE_ALL_REF"] = "1"
     os.environ["CONCH_ENABLE_BNB"] = "1"
+    os.environ["CONCH_ENABLE_TORCHVISION"] = "1"
     os.environ["CONCH_ENABLE_VLLM"] = "1"
     os.environ["VLLM_LOGGING_LEVEL"] = "CRITICAL"
 

--- a/tools/create_benchmark_results_table.py
+++ b/tools/create_benchmark_results_table.py
@@ -51,9 +51,25 @@ _DEVICE_SPECIFIC_BLACKLIST: Final = {
 _EXTRA_BENCHMARK_FLAGS: Final = {
     "gelu_tanh_and_mul_benchmark": ["--compile-ref"],
     "silu_and_mul_benchmark": ["--compile-ref"],
+    "rotary_embedding_benchmark": ["--compile-ref"],
     "gemma_rms_norm_benchmark": ["--compile-ref"],
     "rms_norm_benchmark": ["--compile-ref"],
     "varlen_attention_benchmark": ["--causal"],
+}
+
+
+_EXTRA_BENCHMARK_ENV: Final = {
+    "paged_attention_vs_flash_benchmark": {"CONCH_ENABLE_VLLM": "1"},
+    "varlen_attention_benchmark": {"CONCH_ENABLE_VLLM": "1"},
+    "bnb_dequantize_blockwise_benchmark": {"CONCH_ENABLE_BNB": "1", "CONCH_BENCH_ENABLE_ALL_REF": "1"},
+    "bnb_quantize_blockwise_benchmark": {"CONCH_ENABLE_BNB": "1", "CONCH_BENCH_ENABLE_ALL_REF": "1"},
+    "static_scaled_fp8_quant_benchmark": {"CONCH_ENABLE_VLLM": "1"},
+    "static_scaled_int8_quant_benchmark": {"CONCH_ENABLE_VLLM": "1"},
+    "mixed_precision_gemm_benchmark": {"CONCH_ENABLE_VLLM": "1", "CONCH_BENCH_ENABLE_ALL_REF": "1"},
+    "scaled_gemm_benchmark": {"CONCH_ENABLE_VLLM": "1", "CONCH_BENCH_ENABLE_ALL_REF": "1"},
+    "nms_benchmark": {"CONCH_ENABLE_TORCHVISION": "1"},
+    "copy_blocks_benchmark": {"CONCH_ENABLE_VLLM": "1"},
+    "reshape_and_cache_benchmark": {"CONCH_ENABLE_VLLM": "1"},
 }
 
 
@@ -71,11 +87,6 @@ _EXTRA_BENCHMARK_FLAGS: Final = {
 )
 def main(results_directory: Path, use_cached_results: bool) -> None:
     """Main function to plot benchmarking results."""
-    # Always run against fastest possible implementation
-    os.environ["CONCH_BENCH_ENABLE_ALL_REF"] = "1"
-    os.environ["CONCH_ENABLE_BNB"] = "1"
-    os.environ["CONCH_ENABLE_TORCHVISION"] = "1"
-    os.environ["CONCH_ENABLE_VLLM"] = "1"
     os.environ["VLLM_LOGGING_LEVEL"] = "CRITICAL"
 
     # Create directory for output if it doesn't exist already
@@ -102,6 +113,9 @@ def main(results_directory: Path, use_cached_results: bool) -> None:
             # Run benchmark and redirect output
             print(f"Running benchmark for {op_name}...")
 
+            # Some benchmarks need extra environment variables set
+            extra_env = _EXTRA_BENCHMARK_ENV[benchmark_name] if benchmark_name in _EXTRA_BENCHMARK_ENV else {}
+
             # Some benchmark args are flags to enable things that default false, so we add any per-benchmark here
             extra_flags = _EXTRA_BENCHMARK_FLAGS[benchmark_name] if benchmark_name in _EXTRA_BENCHMARK_FLAGS else []
 
@@ -110,7 +124,7 @@ def main(results_directory: Path, use_cached_results: bool) -> None:
                     ["python", f"benchmarks/{benchmark_name}.py", "--csv"] + extra_flags,
                     check=True,
                     stdout=results_file,
-                    env=os.environ,
+                    env=os.environ.copy() | extra_env,
                 )
 
         # Read the CSV file

--- a/tools/plot_benchmark_results.py
+++ b/tools/plot_benchmark_results.py
@@ -34,8 +34,8 @@ from matplotlib import pyplot as plt
     "--triton-tag",
     required=True,
     type=str,
-    default="Triton",
-    help="The 'tag' column value for Triton results.",
+    default="Conch",
+    help="The 'tag' column value for Conch results.",
 )
 @click.option(
     "--baseline-tag",
@@ -60,7 +60,7 @@ def main(results_directory: Path, x_axis: str, y_axis: str, triton_tag: str, bas
     triton_df = df[df["tag"] == triton_tag].sort_values(by=x_axis)
     baseline_df = df[df["tag"] == baseline_tag].sort_values(by=x_axis)
 
-    columns_to_exclude = ["tag", "platform", x_axis, y_axis]
+    columns_to_exclude = ["tag", "platform", "num_iterations", x_axis, y_axis]
     metadata_columns = [col for col in triton_df.columns if col not in columns_to_exclude]
 
     triton_metadata = triton_df[metadata_columns].set_index(metadata_columns[0]).reset_index(drop=True)


### PR DESCRIPTION
### Description

This PR adds a reference implementation, kernel, op, test, and benchmark for Non-Max Suppression (NMS).
The implementation of this kernel is [based on the CUDA reference implementation from Torchvision](https://github.com/pytorch/vision/blob/0721867e42841171254c7acaa45fbaf8ee16d3d7/torchvision/csrc/ops/cuda/nms_kernel.cu).
Our operation also follows [the same interface as the Torchvision API](https://github.com/pytorch/vision/blob/0721867e42841171254c7acaa45fbaf8ee16d3d7/torchvision/ops/boxes.py#L20).

We took a slightly different approach when implementing this kernel; first, we wrote reference PyTorch implementations and tried to use `torch.compile()` to accelerate them. The performance of the `compile()`-d kernels was very poor compared to the CUDA reference (this is somewhat unsurprising, given the parallelization structure of NMS). Next, we implemented the handwritten Triton kernel. Finally, we introduced as many optimizations as possible from the CUDA reference impl.

Our "final" Triton kernel is generally still a bit slower than CUDA, especially for large problem sizes. This is primarily because of two differences in the implementations:
1. The CUDA kernel uses a bitmask to represent the IoU for each column block, which saves the amount of scratch memory that the kernel requires (`N * num_col_blocks` for CUDA vs. `N * N` for Triton).
2. The CUDA kernel uses shared memory to represent the removed mask in the stage2 kernel, whereas the Triton kernel must use HBM. This makes the lookups for whether or not each box has been kept much slower in Triton, and forces us to synchronize after each loop iteration

### Testing

Please select all that apply.

- [ ] Existing unit tests
- [x] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```
# Can also add `CONCH_ENABLE_TORCHVISION=1`
pytest tests/nms_test.py
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [x] AMD GPU
- [ ] Other (please explain)

### Benchmarks

```
python benchmarks/nms_benchmark.py --num-boxes 4096 --gpu-ref --compile-ref --vectorize-ref
```

**A10**

```
Reference vs Conch: Results matched with atol=0.001 :)
Parameters: {'num_boxes': 4096, 'iou_threshold': 0.5}
Conch: num_iterations=2756, min=3.076 ms, max=3.310 ms, mean=3.096 ms, median=3.091 ms
Baseline: num_iterations=13, min=642.600 ms, max=755.242 ms, mean=716.487 ms, median=726.104 ms
PyTorch Reference (Compiled): num_iterations=23, min=404.111 ms, max=466.083 ms, mean=424.135 ms, median=420.500 ms
PyTorch Reference (Vectorized): num_iterations=1, min=165183.766 ms, max=165183.766 ms, mean=165183.766 ms, median=165183.766 ms
PyTorch Reference (Vectorized, Compiled): num_iterations=1, min=181160.094 ms, max=181160.094 ms, mean=181160.094 ms, median=181160.094 ms
PyTorch GPU Reference: num_iterations=5705, min=1.181 ms, max=1.473 ms, mean=1.213 ms, median=1.211 ms
```

**H100**

```
Reference vs Conch: Results matched with atol=0.001 :)
Parameters: {'num_boxes': 4096, 'iou_threshold': 0.5}
Conch: num_iterations=6224, min=1.479 ms, max=2.487 ms, mean=1.507 ms, median=1.503 ms
Baseline: num_iterations=21, min=457.674 ms, max=517.613 ms, mean=463.726 ms, median=460.260 ms
PyTorch Reference (Compiled): num_iterations=33, min=293.638 ms, max=359.811 ms, mean=301.033 ms, median=296.215 ms
PyTorch Reference (Vectorized): num_iterations=1, min=123716.055 ms, max=123716.055 ms, mean=123716.055 ms, median=123716.055 ms
PyTorch Reference (Vectorized, Compiled): num_iterations=1, min=124315.828 ms, max=124315.828 ms, mean=124315.828 ms, median=124315.828 ms
PyTorch GPU Reference: num_iterations=11380, min=0.743 ms, max=5.353 ms, mean=0.764 ms, median=0.761 ms
```

**MI300X**

```
Reference vs Conch: Results matched with atol=0.001 :)
Parameters: {'num_boxes': 4096, 'iou_threshold': 0.5}
Conch: num_iterations=5374, min=1.803 ms, max=11.276 ms, mean=1.829 ms, median=1.822 ms
Baseline: num_iterations=22, min=441.022 ms, max=455.029 ms, mean=445.137 ms, median=443.703 ms
PyTorch Reference (Compiled): num_iterations=37, min=260.512 ms, max=274.488 ms, mean=263.063 ms, median=262.745 ms
PyTorch Reference (Vectorized): num_iterations=1, min=137248.344 ms, max=137248.344 ms, mean=137248.344 ms, median=137248.344 ms
PyTorch Reference (Vectorized, Compiled): num_iterations=1, min=137764.391 ms, max=137764.391 ms, mean=137764.391 ms, median=137764.391 ms
PyTorch GPU Reference: num_iterations=10252, min=0.903 ms, max=1.466 ms, mean=0.921 ms, median=0.920 ms
```