### PR TITLE
Add BEVPool Kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,12 @@ dist/
 results/
 
 .coverage
+
 .vscode
+
+# Ignore any shared libraries
+*.so
+
+# Ignore HIP-ified CUDA kernels
+conch_cuda_ext/**/*_hip.cc
+conch_cuda_ext/**/*.hip

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Check out the [developer instructions](./docs/getting_started/developer_environm
 
 We were inspired by and leverage components of the following libraries:
 
+- [BEVFusion](https://github.com/mit-han-lab/bevfusion)
 - [bitsandbytes](https://github.com/bitsandbytes-foundation/bitsandbytes)
 - [GemLite](https://github.com/mobiusml/gemlite)
 - [Torchvision](https://github.com/pytorch/vision)

--- a/benchmarks/bev_pool_backward_benchmark.py
+++ b/benchmarks/bev_pool_backward_benchmark.py
@@ -53,7 +53,7 @@ def _create_bev_pool_backward_data(
             torch.randint(0, batch_size, (num_points,), device=device),  # Batch index
         ],
         dim=1,
-    ).long()
+    ).to(torch.int32)
 
     # Create a linear index for sorting and grouping
     linear_indices = (
@@ -72,8 +72,8 @@ def _create_bev_pool_backward_data(
     num_intervals = len(unique_indices)
 
     # Create interval starts and lengths
-    interval_starts = torch.zeros(num_intervals, device=device, dtype=torch.long)
-    interval_lengths = counts.long()
+    interval_starts = torch.zeros(num_intervals, device=device, dtype=torch.int32)
+    interval_lengths = counts.to(torch.int32)
 
     current_start = 0
     for i in range(num_intervals):
@@ -252,7 +252,13 @@ def main(
         interval_lengths,
     )
 
-    ref_output = bev_pool_backward_ref_fn(*args)
+    ref_output = bev_pool_backward_ref_fn(
+        *args,
+        batch_size=batch_size,
+        grid_cells_z=grid_cells_z,
+        grid_cells_x=grid_cells_x,
+        grid_cells_y=grid_cells_y,
+    )
     conch_output = bev_pool_backward_conch_fn(*args)
 
     # Accuracy checks
@@ -269,7 +275,13 @@ def main(
 
     # Benchmark implementations
     baseline_result = benchmark_it(
-        lambda: bev_pool_backward_ref_fn(*args),
+        lambda: bev_pool_backward_ref_fn(
+            *args,
+            batch_size=batch_size,
+            grid_cells_z=grid_cells_z,
+            grid_cells_x=grid_cells_x,
+            grid_cells_y=grid_cells_y,
+        ),
         tag="Baseline",
         metadata=metadata,
         iteration_time_ms=iteration_time_ms,

--- a/benchmarks/bev_pool_backward_benchmark.py
+++ b/benchmarks/bev_pool_backward_benchmark.py
@@ -1,0 +1,294 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+"""BEV Pool backward pass benchmark."""
+
+import sys
+from typing import Final
+
+import click
+import torch
+
+from conch.ops.vision.bev_pool import bev_pool_backward as bev_pool_backward_conch
+from conch.platforms import current_platform
+from conch.reference.vision.bev_pool import bev_pool_backward as bev_pool_backward_ref
+from conch.third_party.vllm.utils import seed_everything
+from conch.utils.benchmark import BenchmarkMetadata, benchmark_it
+
+
+def _create_bev_pool_backward_data(
+    num_points: int,
+    num_channels: int,
+    batch_size: int,
+    grid_cells_z: int,
+    grid_cells_x: int,
+    grid_cells_y: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Create test data for BEV Pool backward operation.
+
+    Args:
+        num_points: Number of input points.
+        num_channels: Number of feature channels per point.
+        batch_size: Number of batches.
+        grid_cells_z: Number of Z grid cells.
+        grid_cells_x: Number of X grid cells.
+        grid_cells_y: Number of Y grid cells.
+        device: Device to create tensors on.
+
+    Returns:
+        Tuple of (grad_output, geom_feats, interval_starts, interval_lengths).
+    """
+    # Create random gradient output in the shape of BEV pool output
+    grad_output = torch.randn(
+        batch_size, grid_cells_z, grid_cells_x, grid_cells_y, num_channels, device=device, dtype=torch.float32
+    )
+
+    # Create geometry features with random but valid coordinates
+    geom_feats = torch.stack(
+        [
+            torch.randint(0, grid_cells_x, (num_points,), device=device),  # X coordinate
+            torch.randint(0, grid_cells_y, (num_points,), device=device),  # Y coordinate
+            torch.randint(0, grid_cells_z, (num_points,), device=device),  # Z coordinate
+            torch.randint(0, batch_size, (num_points,), device=device),  # Batch index
+        ],
+        dim=1,
+    ).long()
+
+    # Create a linear index for sorting and grouping
+    linear_indices = (
+        geom_feats[:, 3] * (grid_cells_z * grid_cells_x * grid_cells_y)  # batch
+        + geom_feats[:, 2] * (grid_cells_x * grid_cells_y)  # z
+        + geom_feats[:, 1] * grid_cells_y  # x
+        + geom_feats[:, 0]  # y
+    )
+
+    # Sort by linear indices to group points in same voxels
+    sorted_indices = torch.argsort(linear_indices)
+    sorted_linear_indices = linear_indices[sorted_indices]
+
+    # Find unique voxels and create intervals
+    unique_indices, counts = torch.unique_consecutive(sorted_linear_indices, return_counts=True)
+    num_intervals = len(unique_indices)
+
+    # Create interval starts and lengths
+    interval_starts = torch.zeros(num_intervals, device=device, dtype=torch.long)
+    interval_lengths = counts.long()
+
+    current_start = 0
+    for i in range(num_intervals):
+        interval_starts[i] = current_start
+        current_start += interval_lengths[i]
+
+    # Reorder geometry by sorted indices
+    geom_feats = geom_feats[sorted_indices]
+
+    return grad_output, geom_feats, interval_starts, interval_lengths
+
+
+@click.command()
+@click.option(
+    "--num-points",
+    required=False,
+    type=int,
+    default=10000,
+    help="Number of input points",
+)
+@click.option(
+    "--num-channels",
+    required=False,
+    type=int,
+    default=64,
+    help="Number of feature channels per point",
+)
+@click.option(
+    "--batch-size",
+    required=False,
+    type=int,
+    default=2,
+    help="Batch size",
+)
+@click.option(
+    "--grid-cells-z",
+    required=False,
+    type=int,
+    default=16,
+    help="Number of Z grid cells",
+)
+@click.option(
+    "--grid-cells-x",
+    required=False,
+    type=int,
+    default=200,
+    help="Number of X grid cells",
+)
+@click.option(
+    "--grid-cells-y",
+    required=False,
+    type=int,
+    default=200,
+    help="Number of Y grid cells",
+)
+@click.option(
+    "--iteration-time-ms",
+    required=False,
+    type=int,
+    default=10000,
+    help="Time in milliseconds to run benchmark",
+)
+@click.option(
+    "--warmup-time-ms",
+    required=False,
+    type=int,
+    default=1000,
+    help="Time in milliseconds to warmup before recording times",
+)
+@click.option(
+    "--absolute-tolerance",
+    required=False,
+    type=float,
+    default=1e-3,
+    help="Absolute tolerance to match with",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Flag for printing verbose output",
+)
+@click.option(
+    "--gpu",
+    required=False,
+    type=str,
+    default=current_platform.device,
+    help="Device to run on",
+)
+@click.option(
+    "--csv",
+    is_flag=True,
+    help="Flag for printing results in CSV format",
+)
+@click.option(
+    "--compile-ref",
+    is_flag=True,
+    help="Flag to torch.compile() the reference impl",
+)
+@click.option(
+    "--compile-conch",
+    is_flag=True,
+    help="Flag to torch.compile() the Conch impl",
+)
+def main(
+    num_points: int,
+    num_channels: int,
+    batch_size: int,
+    grid_cells_z: int,
+    grid_cells_x: int,
+    grid_cells_y: int,
+    iteration_time_ms: int,
+    warmup_time_ms: int,
+    absolute_tolerance: float,
+    verbose: bool,
+    gpu: str,
+    csv: bool,
+    compile_ref: bool,
+    compile_conch: bool,
+) -> None:
+    """Benchmark BEV Pool backward pass.
+
+    Args:
+        num_points: Number of input points.
+        num_channels: Number of feature channels per point.
+        batch_size: Batch size.
+        grid_cells_z: Number of Z grid cells.
+        grid_cells_x: Number of X grid cells.
+        grid_cells_y: Number of Y grid cells.
+        iteration_time_ms: Time in milliseconds to run benchmark.
+        warmup_time_ms: Time in milliseconds to warmup before recording times.
+        absolute_tolerance: Absolute tolerance used to check accuracy.
+        verbose: Flag to indicate whether or not to print verbose output.
+        gpu: Which gpu to run on.
+        csv: Flag to indicate whether or not to print results in CSV format.
+        compile_ref: Flag to torch.compile() the reference implementation.
+        compile_conch: Flag to torch.compile() the Conch implementation.
+    """
+    seed: Final = 0
+    seed_everything(seed)
+
+    device: Final = torch.device(gpu)
+    torch.set_default_device(device)
+
+    metadata = BenchmarkMetadata(
+        platform=current_platform.name(),
+        params={
+            "num_points": num_points,
+            "num_channels": num_channels,
+            "batch_size": batch_size,
+            "grid_cells_z": grid_cells_z,
+            "grid_cells_x": grid_cells_x,
+            "grid_cells_y": grid_cells_y,
+        },
+    )
+
+    # Create test data
+    grad_output, geom_feats, interval_starts, interval_lengths = _create_bev_pool_backward_data(
+        num_points=num_points,
+        num_channels=num_channels,
+        batch_size=batch_size,
+        grid_cells_z=grid_cells_z,
+        grid_cells_x=grid_cells_x,
+        grid_cells_y=grid_cells_y,
+        device=device,
+    )
+
+    # Compile functions if requested
+    bev_pool_backward_ref_fn = torch.compile(bev_pool_backward_ref) if compile_ref else bev_pool_backward_ref
+    bev_pool_backward_conch_fn = torch.compile(bev_pool_backward_conch) if compile_conch else bev_pool_backward_conch
+
+    # Test both implementations
+    args = (
+        grad_output,
+        geom_feats,
+        interval_starts,
+        interval_lengths,
+    )
+
+    ref_output = bev_pool_backward_ref_fn(*args)
+    conch_output = bev_pool_backward_conch_fn(*args)
+
+    # Accuracy checks
+    if not torch.allclose(ref_output, conch_output, atol=absolute_tolerance):
+        print(f"WARNING: Reference and Conch results differ! (atol={absolute_tolerance})", file=sys.stderr)
+        print(f"Output max diff: {(ref_output - conch_output).abs().max().item()}", file=sys.stderr)
+        print(f"Ref shape: {ref_output.shape}, Conch shape: {conch_output.shape}", file=sys.stderr)
+
+        if verbose:
+            print(f"Reference output: {ref_output}", file=sys.stderr)
+            print(f"Conch output: {conch_output}", file=sys.stderr)
+    else:
+        print(f"Reference vs Conch: Results matched with atol={absolute_tolerance} :)", file=sys.stderr)
+
+    # Benchmark implementations
+    baseline_result = benchmark_it(
+        lambda: bev_pool_backward_ref_fn(*args),
+        tag="Baseline",
+        metadata=metadata,
+        iteration_time_ms=iteration_time_ms,
+        warmup_time_ms=warmup_time_ms,
+    )
+
+    conch_result = benchmark_it(
+        lambda: bev_pool_backward_conch_fn(*args),
+        tag="Conch",
+        metadata=metadata,
+        iteration_time_ms=iteration_time_ms,
+        warmup_time_ms=warmup_time_ms,
+    )
+
+    # Print results
+    conch_result.print_parameters(csv=csv)
+    conch_result.print_results(csv=csv)
+    baseline_result.print_results(csv=csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bev_pool_backward_benchmark.py
+++ b/benchmarks/bev_pool_backward_benchmark.py
@@ -91,7 +91,7 @@ def _create_bev_pool_backward_data(
     "--num-points",
     required=False,
     type=int,
-    default=10000,
+    default=500000,
     help="Number of input points",
 )
 @click.option(
@@ -105,28 +105,28 @@ def _create_bev_pool_backward_data(
     "--batch-size",
     required=False,
     type=int,
-    default=2,
+    default=1,
     help="Batch size",
 )
 @click.option(
     "--grid-cells-z",
     required=False,
     type=int,
-    default=16,
+    default=32,
     help="Number of Z grid cells",
 )
 @click.option(
     "--grid-cells-x",
     required=False,
     type=int,
-    default=200,
+    default=250,
     help="Number of X grid cells",
 )
 @click.option(
     "--grid-cells-y",
     required=False,
     type=int,
-    default=200,
+    default=250,
     help="Number of Y grid cells",
 )
 @click.option(

--- a/benchmarks/bev_pool_benchmark.py
+++ b/benchmarks/bev_pool_benchmark.py
@@ -176,6 +176,11 @@ def _create_bev_pool_data(
     is_flag=True,
     help="Flag to torch.compile() the Conch impl",
 )
+@click.option(
+    "--cuda-ref",
+    is_flag=True,
+    help="Flag to enable CUDA reference implementation",
+)
 def main(
     num_points: int,
     num_channels: int,
@@ -191,6 +196,7 @@ def main(
     csv: bool,
     compile_ref: bool,
     compile_conch: bool,
+    cuda_ref: bool,
 ) -> None:
     """Benchmark BEV Pool.
 
@@ -209,6 +215,7 @@ def main(
         csv: Flag to indicate whether or not to print results in CSV format.
         compile_ref: Flag to torch.compile() the reference implementation.
         compile_conch: Flag to torch.compile() the Conch implementation.
+        cuda_ref: Flag to enable CUDA reference implementation.
     """
     seed: Final = 0
     seed_everything(seed)
@@ -245,8 +252,21 @@ def main(
     print(f"Max interval length: {interval_lengths.float().max().item()}", file=sys.stderr)
 
     # Compile functions if requested
-    bev_pool_ref_fn = torch.compile(bev_pool_ref) if compile_ref else bev_pool_ref
-    bev_pool_conch_fn = torch.compile(bev_pool_conch) if compile_conch else bev_pool_conch
+    bev_pool_forward_compiled_fn = None
+    bev_pool_forward_cuda_fn = None
+
+    if compile_ref:
+        # Compile the reference implementation if requested
+        bev_pool_forward_compiled_fn = torch.compile(bev_pool_ref)
+
+    if cuda_ref:
+        from conch_cuda_ext.ops.vision.bev_pool.bev_pool import bev_pool_forward as bev_pool_fwd_cuda
+
+        bev_pool_forward_cuda_fn = bev_pool_fwd_cuda
+
+    bev_pool_forward_conch_compiled_fn = None
+    if compile_conch:
+        bev_pool_forward_conch_compiled_fn = torch.compile(bev_pool_conch)
 
     # Test both implementations
     args = (
@@ -260,8 +280,8 @@ def main(
         grid_cells_y,
     )
 
-    ref_output = bev_pool_ref_fn(*args)
-    conch_output = bev_pool_conch_fn(*args)
+    ref_output = bev_pool_ref(*args)
+    conch_output = bev_pool_conch(*args)
 
     # Accuracy checks
     if not torch.allclose(ref_output, conch_output, atol=absolute_tolerance):
@@ -277,7 +297,7 @@ def main(
 
     # Benchmark implementations
     baseline_result = benchmark_it(
-        lambda: bev_pool_ref_fn(*args),
+        lambda: bev_pool_ref(*args),
         tag="Baseline",
         metadata=metadata,
         iteration_time_ms=iteration_time_ms,
@@ -285,17 +305,54 @@ def main(
     )
 
     conch_result = benchmark_it(
-        lambda: bev_pool_conch_fn(*args),
+        lambda: bev_pool_conch(*args),
         tag="Conch",
         metadata=metadata,
         iteration_time_ms=iteration_time_ms,
         warmup_time_ms=warmup_time_ms,
     )
 
+    reference_compiled_result = None
+    reference_cuda_result = None
+    conch_compiled_result = None
+
+    if bev_pool_forward_compiled_fn:
+        reference_compiled_result = benchmark_it(
+            lambda: bev_pool_forward_compiled_fn(*args),
+            tag="Reference (Compiled)",
+            metadata=metadata,
+            iteration_time_ms=iteration_time_ms,
+            warmup_time_ms=warmup_time_ms,
+        )
+
+    if bev_pool_forward_cuda_fn:
+        reference_cuda_result = benchmark_it(
+            lambda: bev_pool_forward_cuda_fn(*args),
+            tag="CUDA",
+            metadata=metadata,
+            iteration_time_ms=iteration_time_ms,
+            warmup_time_ms=warmup_time_ms,
+        )
+
+    if bev_pool_forward_conch_compiled_fn:
+        conch_compiled_result = benchmark_it(
+            lambda: bev_pool_forward_conch_compiled_fn(*args),
+            tag="Conch (Compiled)",
+            metadata=metadata,
+            iteration_time_ms=iteration_time_ms,
+            warmup_time_ms=warmup_time_ms,
+        )
+
     # Print results
     conch_result.print_parameters(csv=csv)
     conch_result.print_results(csv=csv)
     baseline_result.print_results(csv=csv)
+    if reference_compiled_result:
+        reference_compiled_result.print_results(csv=csv)
+    if reference_cuda_result:
+        reference_cuda_result.print_results(csv=csv)
+    if conch_compiled_result:
+        conch_compiled_result.print_results(csv=csv)
 
 
 if __name__ == "__main__":

--- a/benchmarks/bev_pool_benchmark.py
+++ b/benchmarks/bev_pool_benchmark.py
@@ -1,0 +1,297 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+"""BEV Pool benchmark."""
+
+import sys
+from typing import Final
+
+import click
+import torch
+
+from conch.ops.vision.bev_pool import bev_pool as bev_pool_conch
+from conch.platforms import current_platform
+from conch.reference.vision.bev_pool import bev_pool as bev_pool_ref
+from conch.third_party.vllm.utils import seed_everything
+from conch.utils.benchmark import BenchmarkMetadata, benchmark_it
+
+
+def _create_bev_pool_data(
+    num_points: int,
+    num_channels: int,
+    batch_size: int,
+    grid_cells_z: int,
+    grid_cells_x: int,
+    grid_cells_y: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Create test data for BEV Pool operation.
+
+    Args:
+        num_points: Number of input points.
+        num_channels: Number of feature channels per point.
+        batch_size: Number of batches.
+        grid_cells_z: Number of Z grid cells.
+        grid_cells_x: Number of X grid cells.
+        grid_cells_y: Number of Y grid cells.
+        device: Device to create tensors on.
+
+    Returns:
+        Tuple of (image_feats, geom_feats, interval_starts, interval_lengths).
+    """
+    # Create random image features
+    image_feats = torch.randn(num_points, num_channels, device=device, dtype=torch.float32)
+
+    # Create geometry features with random but valid coordinates
+    geom_feats = torch.stack(
+        [
+            torch.randint(0, grid_cells_x, (num_points,), device=device),  # X coordinate
+            torch.randint(0, grid_cells_y, (num_points,), device=device),  # Y coordinate
+            torch.randint(0, grid_cells_z, (num_points,), device=device),  # Z coordinate
+            torch.randint(0, batch_size, (num_points,), device=device),  # Batch index
+        ],
+        dim=1,
+    ).long()
+
+    # Create a linear index for sorting and grouping
+    linear_indices = (
+        geom_feats[:, 3] * (grid_cells_z * grid_cells_x * grid_cells_y)  # batch
+        + geom_feats[:, 2] * (grid_cells_x * grid_cells_y)  # z
+        + geom_feats[:, 1] * grid_cells_y  # x
+        + geom_feats[:, 0]  # y
+    )
+
+    # Sort by linear indices to group points in same voxels
+    sorted_indices = torch.argsort(linear_indices)
+    sorted_linear_indices = linear_indices[sorted_indices]
+
+    # Find unique voxels and create intervals
+    unique_indices, counts = torch.unique_consecutive(sorted_linear_indices, return_counts=True)
+    num_intervals = len(unique_indices)
+
+    # Create interval starts and lengths
+    interval_starts = torch.zeros(num_intervals, device=device, dtype=torch.long)
+    interval_lengths = counts.long()
+
+    current_start = 0
+    for i in range(num_intervals):
+        interval_starts[i] = current_start
+        current_start += interval_lengths[i]
+
+    # Reorder features and geometry by sorted indices
+    image_feats = image_feats[sorted_indices]
+    geom_feats = geom_feats[sorted_indices]
+
+    return image_feats, geom_feats, interval_starts, interval_lengths
+
+
+@click.command()
+@click.option(
+    "--num-points",
+    required=False,
+    type=int,
+    default=10000,
+    help="Number of input points",
+)
+@click.option(
+    "--num-channels",
+    required=False,
+    type=int,
+    default=64,
+    help="Number of feature channels per point",
+)
+@click.option(
+    "--batch-size",
+    required=False,
+    type=int,
+    default=2,
+    help="Batch size",
+)
+@click.option(
+    "--grid-cells-z",
+    required=False,
+    type=int,
+    default=16,
+    help="Number of Z grid cells",
+)
+@click.option(
+    "--grid-cells-x",
+    required=False,
+    type=int,
+    default=200,
+    help="Number of X grid cells",
+)
+@click.option(
+    "--grid-cells-y",
+    required=False,
+    type=int,
+    default=200,
+    help="Number of Y grid cells",
+)
+@click.option(
+    "--iteration-time-ms",
+    required=False,
+    type=int,
+    default=10000,
+    help="Time in milliseconds to run benchmark",
+)
+@click.option(
+    "--warmup-time-ms",
+    required=False,
+    type=int,
+    default=1000,
+    help="Time in milliseconds to warmup before recording times",
+)
+@click.option(
+    "--absolute-tolerance",
+    required=False,
+    type=float,
+    default=1e-3,
+    help="Absolute tolerance to match with",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Flag for printing verbose output",
+)
+@click.option(
+    "--gpu",
+    required=False,
+    type=str,
+    default=current_platform.device,
+    help="Device to run on",
+)
+@click.option(
+    "--csv",
+    is_flag=True,
+    help="Flag for printing results in CSV format",
+)
+@click.option(
+    "--compile-ref",
+    is_flag=True,
+    help="Flag to torch.compile() the reference impl",
+)
+@click.option(
+    "--compile-conch",
+    is_flag=True,
+    help="Flag to torch.compile() the Conch impl",
+)
+def main(
+    num_points: int,
+    num_channels: int,
+    batch_size: int,
+    grid_cells_z: int,
+    grid_cells_x: int,
+    grid_cells_y: int,
+    iteration_time_ms: int,
+    warmup_time_ms: int,
+    absolute_tolerance: float,
+    verbose: bool,
+    gpu: str,
+    csv: bool,
+    compile_ref: bool,
+    compile_conch: bool,
+) -> None:
+    """Benchmark BEV Pool.
+
+    Args:
+        num_points: Number of input points.
+        num_channels: Number of feature channels per point.
+        batch_size: Batch size.
+        grid_cells_z: Number of Z grid cells.
+        grid_cells_x: Number of X grid cells.
+        grid_cells_y: Number of Y grid cells.
+        iteration_time_ms: Time in milliseconds to run benchmark.
+        warmup_time_ms: Time in milliseconds to warmup before recording times.
+        absolute_tolerance: Absolute tolerance used to check accuracy.
+        verbose: Flag to indicate whether or not to print verbose output.
+        gpu: Which gpu to run on.
+        csv: Flag to indicate whether or not to print results in CSV format.
+        compile_ref: Flag to torch.compile() the reference implementation.
+        compile_conch: Flag to torch.compile() the Conch implementation.
+    """
+    seed: Final = 0
+    seed_everything(seed)
+
+    device: Final = torch.device(gpu)
+    torch.set_default_device(device)
+
+    metadata = BenchmarkMetadata(
+        platform=current_platform.name(),
+        params={
+            "num_points": num_points,
+            "num_channels": num_channels,
+            "batch_size": batch_size,
+            "grid_cells_z": grid_cells_z,
+            "grid_cells_x": grid_cells_x,
+            "grid_cells_y": grid_cells_y,
+        },
+    )
+
+    # Create test data
+    image_feats, geom_feats, interval_starts, interval_lengths = _create_bev_pool_data(
+        num_points=num_points,
+        num_channels=num_channels,
+        batch_size=batch_size,
+        grid_cells_z=grid_cells_z,
+        grid_cells_x=grid_cells_x,
+        grid_cells_y=grid_cells_y,
+        device=device,
+    )
+
+    # Compile functions if requested
+    bev_pool_ref_fn = torch.compile(bev_pool_ref) if compile_ref else bev_pool_ref
+    bev_pool_conch_fn = torch.compile(bev_pool_conch) if compile_conch else bev_pool_conch
+
+    # Test both implementations
+    args = (
+        image_feats,
+        geom_feats,
+        interval_starts,
+        interval_lengths,
+        batch_size,
+        grid_cells_z,
+        grid_cells_x,
+        grid_cells_y,
+    )
+
+    ref_output = bev_pool_ref_fn(*args)
+    conch_output = bev_pool_conch_fn(*args)
+
+    # Accuracy checks
+    if not torch.allclose(ref_output, conch_output, atol=absolute_tolerance):
+        print(f"WARNING: Reference and Conch results differ! (atol={absolute_tolerance})", file=sys.stderr)
+        print(f"Output max diff: {(ref_output - conch_output).abs().max().item()}", file=sys.stderr)
+        print(f"Ref shape: {ref_output.shape}, Conch shape: {conch_output.shape}", file=sys.stderr)
+
+        if verbose:
+            print(f"Reference output: {ref_output}", file=sys.stderr)
+            print(f"Conch output: {conch_output}", file=sys.stderr)
+    else:
+        print(f"Reference vs Conch: Results matched with atol={absolute_tolerance} :)", file=sys.stderr)
+
+    # Benchmark implementations
+    baseline_result = benchmark_it(
+        lambda: bev_pool_ref_fn(*args),
+        tag="Baseline",
+        metadata=metadata,
+        iteration_time_ms=iteration_time_ms,
+        warmup_time_ms=warmup_time_ms,
+    )
+
+    conch_result = benchmark_it(
+        lambda: bev_pool_conch_fn(*args),
+        tag="Conch",
+        metadata=metadata,
+        iteration_time_ms=iteration_time_ms,
+        warmup_time_ms=warmup_time_ms,
+    )
+
+    # Print results
+    conch_result.print_parameters(csv=csv)
+    conch_result.print_results(csv=csv)
+    baseline_result.print_results(csv=csv)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/bev_pool_benchmark.py
+++ b/benchmarks/bev_pool_benchmark.py
@@ -45,13 +45,13 @@ def _create_bev_pool_data(
     # Create geometry features with random but valid coordinates
     geom_feats = torch.stack(
         [
-            torch.randint(0, grid_cells_x, (num_points,), device=device),  # X coordinate
-            torch.randint(0, grid_cells_y, (num_points,), device=device),  # Y coordinate
-            torch.randint(0, grid_cells_z, (num_points,), device=device),  # Z coordinate
-            torch.randint(0, batch_size, (num_points,), device=device),  # Batch index
+            torch.randint(0, grid_cells_x, (num_points,), dtype=torch.int32, device=device),  # X coordinate
+            torch.randint(0, grid_cells_y, (num_points,), dtype=torch.int32, device=device),  # Y coordinate
+            torch.randint(0, grid_cells_z, (num_points,), dtype=torch.int32, device=device),  # Z coordinate
+            torch.randint(0, batch_size, (num_points,), dtype=torch.int32, device=device),  # Batch index
         ],
         dim=1,
-    ).long()
+    ).to(torch.int32)
 
     # Create a linear index for sorting and grouping
     linear_indices = (
@@ -70,8 +70,8 @@ def _create_bev_pool_data(
     num_intervals = len(unique_indices)
 
     # Create interval starts and lengths
-    interval_starts = torch.zeros(num_intervals, device=device, dtype=torch.long)
-    interval_lengths = counts.long()
+    interval_starts = torch.zeros(num_intervals, device=device, dtype=torch.int32)
+    interval_lengths = counts.to(torch.int32)
 
     current_start = 0
     for i in range(num_intervals):

--- a/benchmarks/bev_pool_benchmark.py
+++ b/benchmarks/bev_pool_benchmark.py
@@ -90,7 +90,7 @@ def _create_bev_pool_data(
     "--num-points",
     required=False,
     type=int,
-    default=10000,
+    default=6000000,
     help="Number of input points",
 )
 @click.option(
@@ -104,28 +104,28 @@ def _create_bev_pool_data(
     "--batch-size",
     required=False,
     type=int,
-    default=2,
+    default=1,
     help="Batch size",
 )
 @click.option(
     "--grid-cells-z",
     required=False,
     type=int,
-    default=16,
+    default=20,
     help="Number of Z grid cells",
 )
 @click.option(
     "--grid-cells-x",
     required=False,
     type=int,
-    default=200,
+    default=800,
     help="Number of X grid cells",
 )
 @click.option(
     "--grid-cells-y",
     required=False,
     type=int,
-    default=200,
+    default=800,
     help="Number of Y grid cells",
 )
 @click.option(
@@ -238,6 +238,11 @@ def main(
         grid_cells_y=grid_cells_y,
         device=device,
     )
+
+    print(f"Number of intervals: {len(interval_starts)}", file=sys.stderr)
+    print(f"Min interval length: {interval_lengths.float().min().item()}", file=sys.stderr)
+    print(f"Mean interval length: {interval_lengths.float().mean().item()}", file=sys.stderr)
+    print(f"Max interval length: {interval_lengths.float().max().item()}", file=sys.stderr)
 
     # Compile functions if requested
     bev_pool_ref_fn = torch.compile(bev_pool_ref) if compile_ref else bev_pool_ref

--- a/conch/README.md
+++ b/conch/README.md
@@ -2,11 +2,12 @@
 
 ## Envs
 
-Here is a running directory of the various envrionment variables:
+Here is a running directory of the various environment variables:
 
 | Variable | Options | Meaning |
 | ---| ---| ---|
 | `CONCH_BENCH_ENABLE_ALL_REF` | `1` or `true` (case in-sensitive) | Toggles whether or not to use bitsandbytes/vLLM reference implementations for benchmarking. |
 | `CONCH_ENABLE_BNB` | `1` or `true` (case in-sensitive) | Toggles whether or not to use bitsandbytes reference implementations. |
+| `CONCH_ENABLE_CUDA_EXT` | `1` or `true` (case in-sensitive) | Toggles whether or not to use Conch CUDA extension reference implementations. |
 | `CONCH_ENABLE_TORCHVISION` | `1` or `true` (case in-sensitive) | Toggles whether or not to use torchvision reference implementations. |
 | `CONCH_ENABLE_VLLM` | `1` or `true` (case in-sensitive) | Toggles whether or not to use vLLM reference implementations. |

--- a/conch/envs.py
+++ b/conch/envs.py
@@ -20,6 +20,8 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Enable bitsandbytes kernels for testing/benchmarking
     "CONCH_ENABLE_BNB": lambda: (os.environ.get("CONCH_ENABLE_BNB", "0").strip().lower() in ("1", "true")),
+    # Enable CUDA extension kernels for testing/benchmarking
+    "CONCH_ENABLE_CUDA_EXT": lambda: (os.environ.get("CONCH_ENABLE_CUDA_EXT", "0").strip().lower() in ("1", "true")),
     # Enable torchvision kernels for testing/benchmarking
     "CONCH_ENABLE_TORCHVISION": lambda: (
         os.environ.get("CONCH_ENABLE_TORCHVISION", "0").strip().lower() in ("1", "true")

--- a/conch/kernels/vision/bev_pool.py
+++ b/conch/kernels/vision/bev_pool.py
@@ -1,0 +1,163 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Quick cumsum kernel for 3D voxel grids."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit  # type: ignore[misc]
+def _bev_pool_kernel(
+    # Pointers to tensors
+    output_ptr: tl.tensor,
+    image_feats_ptr: tl.tensor,
+    geom_feats_ptr: tl.tensor,
+    interval_starts_ptr: tl.tensor,
+    interval_lengths_ptr: tl.tensor,
+    # Scalars
+    num_channels: tl.int32,
+    # Strides
+    image_feats_stride: tl.int32,
+    geom_feats_stride: tl.int32,
+    output_batch_stride: tl.int32,
+    output_z_stride: tl.int32,
+    output_x_stride: tl.int32,
+    output_y_stride: tl.int32,
+    # Constexprs
+    cxpr_num_channels_padded: tl.constexpr,
+    cxpr_block_size: tl.constexpr,
+) -> None:
+    """Kernel for quick cumulative sum.
+
+    The geom_feats represent the voxel coordinates in the grid:
+    - geom_feats[:, 0]: X coordinate
+    - geom_feats[:, 1]: Y coordinate
+    - geom_feats[:, 2]: Z coordinate
+    - geom_feats[:, 3]: Batch index
+
+    So for each interval, all pooled points will have the same geom_feats,
+    which means they will be pooled into the same grid cell. We read the image features
+    for each interval and sum them up, then store the result in the output tensor at
+    the corresponding grid cell.
+
+    Args:
+        output_ptr: Pointer to the output tensor, shape: (batch_size, grid_cells_z, grid_cells_x, grid_cells_y, num_channels).
+        image_feats_ptr: Pointer to the input image features, shape: (num_points, num_channels).
+        geom_feats_ptr: Pointer to the input coordinates, shape: (num_points, 4).
+        interval_starts_ptr: Pointer to the starting positions for pooled points, shape: (num_intervals,).
+        interval_lengths_ptr: Pointer to the lengths of each pooled point, shape: (num_intervals,).
+        num_channels: The number of channels in the image features.
+        image_feats_stride: The stride of the image features tensor.
+        geom_feats_stride: The stride of the geometry features tensor.
+        output_batch_stride: The stride of the output tensor for the batch dimension.
+        output_z_stride: The stride of the output tensor for the z dimension.
+        output_x_stride: The stride of the output tensor for the x dimension.
+        output_y_stride: The stride of the output tensor for the y dimension.
+        cxpr_num_channels_padded: The number of channels padded to the next power of 2.
+        cxpr_block_size: The block size for processing points in parallel.
+    """
+    # What is the index of the interval this program is processing?
+    interval_index = tl.program_id(0)
+
+    # Load current interval start and length
+    interval_start = tl.load(interval_starts_ptr + interval_index)
+    interval_length = tl.load(interval_lengths_ptr + interval_index)
+
+    # Offsets and masks for the channels
+    channel_offsets = tl.arange(0, cxpr_num_channels_padded)
+    channel_mask = channel_offsets < num_channels
+
+    # Accumulator for the sum of image features for each channel for all points in the interval
+    output = tl.zeros([cxpr_num_channels_padded], dtype=image_feats_ptr.dtype.element_ty)
+
+    # Calculate the pointer to the start of the image features for the current interval
+    current_image_feats_ptr = image_feats_ptr + interval_start * image_feats_stride + channel_offsets[None, :]
+
+    # Iterate blockwise over the points in the interval
+    for block_index in range(tl.cdiv(interval_length, cxpr_block_size)):
+        # Offsets for the current block
+        block_offsets = block_index * cxpr_block_size + tl.arange(0, cxpr_block_size)
+        # Mask out any indices that are out of bounds for the interval length
+        block_mask = block_offsets < interval_length
+
+        # Load image features, shape: (cxpr_block_size, num_channels)
+        image_feats = tl.load(
+            current_image_feats_ptr + block_offsets[:, None] * image_feats_stride,
+            mask=block_mask[:, None] & channel_mask[None, :],
+            other=0.0,
+        )
+
+        # Calculate sum of image features for the current block, per channel
+        # Shape: (cxpr_num_channels_padded,)
+        output += tl.sum(image_feats, axis=0)
+
+    # Load geometry coordinates for the first point in this interval
+    # Note: all points in the interval share the same geom_feats, so we only need to load the first point's geom_feats.
+    current_geom_feats_ptr = geom_feats_ptr + interval_start * geom_feats_stride
+    geom_x = tl.load(current_geom_feats_ptr + 0)  # X coordinate
+    geom_y = tl.load(current_geom_feats_ptr + 1)  # Y coordinate
+    geom_z = tl.load(current_geom_feats_ptr + 2)  # Z coordinate
+    geom_b = tl.load(current_geom_feats_ptr + 3)  # Batch index
+
+    # Calculate output tensor offset for shape [batch_size, grid_cells_z, grid_cells_x, grid_cells_y, num_channels]
+    batch_offset = geom_b * output_batch_stride
+    z_offset = geom_z * output_z_stride
+    x_offset = geom_x * output_x_stride
+    y_offset = geom_y * output_y_stride
+
+    # Store the accumulated output for the current interval
+    tl.store(
+        output_ptr + batch_offset + z_offset + x_offset + y_offset + channel_offsets,
+        output,
+        mask=channel_mask,
+    )
+
+
+def bev_pool_launcher(
+    output: torch.Tensor,
+    image_feats: torch.Tensor,
+    geom_feats: torch.Tensor,
+    interval_starts: torch.Tensor,
+    interval_lengths: torch.Tensor,
+) -> None:
+    """Launch the quick cumulative sum kernel.
+
+    Args:
+        output: output tensor, shape: (batch_size, grid_cells_z, grid_cells_x, grid_cells_y, num_channels).
+        image_feats: input image features, shape: (num_points, num_channels).
+        geom_feats: input coordinates in form (B, X, Y, Z), shape: (num_points, 4).
+        interval_starts: starting position for pooled point, shape: (num_intervals,).
+        interval_lengths: how many points in each pooled point, shape: (num_intervals,).
+    """
+    _, num_channels = image_feats.shape
+    num_intervals = interval_lengths.size(0)
+
+    # Process each interval in parallel
+    grid = (num_intervals,)
+
+    _bev_pool_kernel[grid](
+        # Pointers to tensors
+        output_ptr=output,
+        image_feats_ptr=image_feats,
+        geom_feats_ptr=geom_feats,
+        interval_starts_ptr=interval_starts,
+        interval_lengths_ptr=interval_lengths,
+        # Scalars
+        num_channels=num_channels,
+        # Strides
+        image_feats_stride=image_feats.stride(0),
+        geom_feats_stride=geom_feats.stride(0),
+        output_batch_stride=output.stride(0),
+        output_z_stride=output.stride(1),
+        output_x_stride=output.stride(2),
+        output_y_stride=output.stride(3),
+        # Constexprs
+        cxpr_num_channels_padded=triton.next_power_of_2(num_channels),
+        # TODO(jmanning): Autotune?
+        # The tricky thing here is the optimal block size depends on the average/maximum interval length,
+        # not the number of intervals or number of points.
+        # It also just may depend on the platform/device what the optimal block size is.
+        cxpr_block_size=64,
+    )

--- a/conch/kernels/vision/bev_pool.py
+++ b/conch/kernels/vision/bev_pool.py
@@ -115,6 +115,103 @@ def _bev_pool_kernel(
     )
 
 
+@triton.jit  # type: ignore[misc]
+def _bev_pool_backward_kernel(
+    # Pointers to tensors
+    x_grad_ptr: tl.tensor,
+    grad_output_ptr: tl.tensor,
+    geom_feats_ptr: tl.tensor,
+    interval_starts_ptr: tl.tensor,
+    interval_lengths_ptr: tl.tensor,
+    # Scalars
+    num_channels: tl.int32,
+    # Strides
+    x_grad_stride: tl.int32,
+    grad_output_batch_stride: tl.int32,
+    grad_output_z_stride: tl.int32,
+    grad_output_x_stride: tl.int32,
+    grad_output_y_stride: tl.int32,
+    geom_feats_stride: tl.int32,
+    # Constexprs
+    cxpr_num_channels_padded: tl.constexpr,
+    cxpr_block_size: tl.constexpr,
+) -> None:
+    """Kernel for backward pass of quick cumulative sum.
+
+    This kernel computes the gradient with respect to the input image features
+    by accumulating gradients from the output tensor.
+
+    Args:
+        x_grad_ptr: Pointer to the gradient with respect to the input image features.
+        grad_output_ptr: Pointer to the gradient of the output tensor.
+        geom_feats_ptr: Pointer to the geometry features tensor.
+        interval_starts_ptr: Pointer to the starting positions for pooled points.
+        interval_lengths_ptr: Pointer to the lengths of each pooled point.
+        num_channels: The number of channels in the image features.
+        x_grad_stride: The stride of the x_grad tensor.
+        grad_output_batch_stride: The stride of the grad_output tensor for the batch dimension.
+        grad_output_z_stride: The stride of the grad_output tensor for the z dimension.
+        grad_output_x_stride: The stride of the grad_output tensor for the x dimension.
+        grad_output_y_stride: The stride of the grad_output tensor for the y dimension.
+        geom_feats_stride: The stride of the geometry features tensor.
+        cxpr_num_channels_padded: The number of channels padded to the next power of 2.
+        cxpr_block_size: The block size for processing points in parallel.
+    """
+    # What is the index of the interval this program is processing?
+    interval_index = tl.program_id(0)
+
+    # Load current interval start and length
+    interval_start = tl.load(interval_starts_ptr + interval_index)
+    interval_length = tl.load(interval_lengths_ptr + interval_index)
+
+    # Offsets and masks for the channels
+    channel_offsets = tl.arange(0, cxpr_num_channels_padded)
+    channel_mask = channel_offsets < num_channels
+
+    # Load geometry coordinates for the first point in this interval
+    # Note: all points in the interval share the same geom_feats, so we only need to load the first point's geom_feats.
+    current_geom_feats_ptr = geom_feats_ptr + interval_start * geom_feats_stride
+    geom_x = tl.load(current_geom_feats_ptr + 0)  # X coordinate
+    geom_y = tl.load(current_geom_feats_ptr + 1)  # Y coordinate
+    geom_z = tl.load(current_geom_feats_ptr + 2)  # Z coordinate
+    geom_b = tl.load(current_geom_feats_ptr + 3)  # Batch index
+
+    # Offset for the entry in the grad_output tensor for this interval
+    grad_output_offset = (
+        geom_b * grad_output_batch_stride
+        + geom_z * grad_output_z_stride
+        + geom_x * grad_output_x_stride
+        + geom_y * grad_output_y_stride
+    )
+
+    # Load gradient output, shape: (num_channels,)
+    grad_output = tl.load(
+        grad_output_ptr + grad_output_offset + channel_offsets,
+        mask=channel_mask,
+        other=0.0,
+    )
+
+    # Broadcast the grad_output to match the block size and number of channels
+    # This is necessary to ensure we can write the gradients in blocks
+    grad_output_expanded = grad_output[None, :].broadcast_to(cxpr_block_size, cxpr_num_channels_padded)
+
+    # Pointer to the start of the output for this block
+    current_x_grad_ptr = x_grad_ptr + interval_start * x_grad_stride + channel_offsets
+
+    for block_index in range(tl.cdiv(interval_length, cxpr_block_size)):
+        # Offsets for the current block
+        block_offsets = block_index * cxpr_block_size + tl.arange(0, cxpr_block_size)
+        # Mask out any indices that are out of bounds for the interval length
+        block_mask = block_offsets < interval_length
+
+        # Store gradients for the current block
+        tl.store(
+            current_x_grad_ptr + block_offsets[:, None] * x_grad_stride,
+            grad_output_expanded,
+            mask=block_mask[:, None] & channel_mask[None, :],
+        )
+
+
 def bev_pool_launcher(
     output: torch.Tensor,
     image_feats: torch.Tensor,
@@ -159,5 +256,49 @@ def bev_pool_launcher(
         # The tricky thing here is the optimal block size depends on the average/maximum interval length,
         # not the number of intervals or number of points.
         # It also just may depend on the platform/device what the optimal block size is.
+        cxpr_block_size=64,
+    )
+
+
+def bev_pool_backward_launcher(
+    x_grad: torch.Tensor,
+    grad_output: torch.Tensor,
+    geom_feats: torch.Tensor,
+    interval_starts: torch.Tensor,
+    interval_lengths: torch.Tensor,
+) -> None:
+    """Launch the backward pass for the BEV Pool operation.
+
+    Args:
+        x_grad: gradient with respect to the input image features, shape: (num_points, num_channels).
+        grad_output: gradient of the output, shape: (batch_size, grid_cells_z, grid_cells_x, grid_cells_y, num_channels).
+        geom_feats: input coordinates in form (B, X, Y, Z), shape: (num_points, 4).
+        interval_starts: starting position for pooled point, shape: (num_intervals,).
+        interval_lengths: how many points in each pooled point, shape: (num_intervals,).
+    """
+    num_intervals = interval_starts.size(0)
+    _, num_channels = x_grad.shape
+
+    # Process each interval in parallel
+    grid = (num_intervals,)
+
+    _bev_pool_backward_kernel[grid](
+        # Pointers to tensors
+        x_grad_ptr=x_grad,
+        grad_output_ptr=grad_output,
+        geom_feats_ptr=geom_feats,
+        interval_starts_ptr=interval_starts,
+        interval_lengths_ptr=interval_lengths,
+        # Scalars
+        num_channels=num_channels,
+        # Strides
+        x_grad_stride=x_grad.stride(0),
+        grad_output_batch_stride=grad_output.stride(0),
+        grad_output_z_stride=grad_output.stride(1),
+        grad_output_x_stride=grad_output.stride(2),
+        grad_output_y_stride=grad_output.stride(3),
+        geom_feats_stride=geom_feats.stride(0),
+        # Constexprs
+        cxpr_num_channels_padded=triton.next_power_of_2(num_channels),
         cxpr_block_size=64,
     )

--- a/conch/ops/vision/bev_pool.py
+++ b/conch/ops/vision/bev_pool.py
@@ -1,0 +1,53 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Quick cumulative sum operator for 3D voxel grids."""
+
+import torch
+
+from conch.kernels.vision.bev_pool import bev_pool_launcher
+
+
+def bev_pool(
+    image_feats: torch.Tensor,
+    geom_feats: torch.Tensor,
+    interval_starts: torch.Tensor,
+    interval_lengths: torch.Tensor,
+    batch_size: int,
+    grid_cells_z: int,
+    grid_cells_x: int,
+    grid_cells_y: int,
+) -> torch.Tensor:
+    """Cumulative sum pooling operator for 3D voxel grids.
+
+    Args:
+        image_feats: input image features, FloatTensor[n, c]
+        geom_feats: input coordinates, IntTensor[n, 4]
+        interval_starts: starting position for pooled point
+        interval_lengths: how many points in each pooled point
+        batch_size: batch size
+        grid_cells_z: number of z cells of the 3D voxel grid
+        grid_cells_x: number of x cells of the 3D voxel grid
+        grid_cells_y: number of y cells of the 3D voxel grid.
+
+    Returns:
+        output features, FloatTensor[batch_size, grid_z_cells, grid_x_cells, grid_y_cells, c]
+    """
+    _, num_channels = image_feats.shape
+
+    # Create output tensor
+    output = torch.zeros(
+        (batch_size, grid_cells_z, grid_cells_x, grid_cells_y, num_channels),
+        dtype=image_feats.dtype,
+        device=image_feats.device,
+    )
+
+    bev_pool_launcher(
+        output=output,
+        image_feats=image_feats,
+        geom_feats=geom_feats,
+        interval_starts=interval_starts,
+        interval_lengths=interval_lengths,
+    )
+
+    return output

--- a/conch/ops/vision/bev_pool.py
+++ b/conch/ops/vision/bev_pool.py
@@ -5,7 +5,7 @@
 
 import torch
 
-from conch.kernels.vision.bev_pool import bev_pool_launcher
+from conch.kernels.vision.bev_pool import bev_pool_backward_launcher, bev_pool_launcher
 
 
 def bev_pool(
@@ -51,3 +51,36 @@ def bev_pool(
     )
 
     return output
+
+
+def bev_pool_backward(
+    grad_output: torch.Tensor,
+    geom_feats: torch.Tensor,
+    interval_starts: torch.Tensor,
+    interval_lengths: torch.Tensor,
+) -> torch.Tensor:
+    """Backward pass for the BEV pooling operation.
+
+    Args:
+        grad_output: gradient of the output, FloatTensor[batch_size, grid_z_cells, grid_x_cells, grid_y_cells, c]
+        geom_feats: input coordinates, IntTensor[n, 4]
+        interval_starts: starting position for pooled point
+        interval_lengths: how many points in each pooled point
+
+    Returns:
+        Gradient with respect to image features.
+    """
+    num_points, _ = geom_feats.shape
+    _, _, _, _, num_channels = grad_output.shape
+
+    x_grad = torch.zeros((num_points, num_channels), dtype=grad_output.dtype, device=grad_output.device)
+
+    bev_pool_backward_launcher(
+        x_grad=x_grad,
+        grad_output=grad_output,
+        geom_feats=geom_feats,
+        interval_starts=interval_starts,
+        interval_lengths=interval_lengths,
+    )
+
+    return x_grad

--- a/conch/reference/vision/bev_pool.py
+++ b/conch/reference/vision/bev_pool.py
@@ -1,0 +1,42 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+
+def bev_pool(
+    image_feats: torch.Tensor,
+    geom_feats: torch.Tensor,
+    interval_starts: torch.Tensor,
+    interval_lengths: torch.Tensor,
+    batch_size: int,
+    grid_cells_z: int,
+    grid_cells_x: int,
+    grid_cells_y: int,
+) -> torch.Tensor:
+    _, num_channels = image_feats.shape
+    num_intervals = interval_lengths.size(0)
+
+    # B, D, H, W, C
+    output = torch.zeros(
+        (batch_size, grid_cells_z, grid_cells_x, grid_cells_y, num_channels),
+        dtype=image_feats.dtype,
+        device=image_feats.device,
+    )
+
+    for i in range(num_intervals):
+        interval_start = interval_starts[i]
+        interval_length = interval_lengths[i]
+
+        # XYZB -> BZXY
+        output_idx = (
+            geom_feats[interval_start, 3],
+            geom_feats[interval_start, 2],
+            geom_feats[interval_start, 0],
+            geom_feats[interval_start, 1],
+        )
+        image_feats_interval_sum = image_feats[interval_start : interval_start + interval_length].sum(dim=0)
+
+        output[output_idx] = image_feats_interval_sum
+
+    return output

--- a/conch_cuda_ext/ops/vision/bev_pool/bev_pool.cc
+++ b/conch_cuda_ext/ops/vision/bev_pool/bev_pool.cc
@@ -1,0 +1,99 @@
+// Copyright 2025 Stack AV Co.
+// SPDX-License-Identifier: Apache-2.0
+
+// https://github.com/mit-han-lab/bevfusion/blob/326653dc06e0938edf1aae7d01efcd158ba83de5/mmdet3d/ops/bev_pool/src/bev_pool_cpu.cpp
+
+#include <torch/torch.h>
+#include <c10/cuda/CUDAGuard.h>
+
+// CUDA function declarations
+void bev_pool(int b, int d, int h, int w, int n, int c, int n_intervals, const float* x,
+    const int* geom_feats, const int* interval_starts, const int* interval_lengths, float* out);
+
+void bev_pool_grad(int b, int d, int h, int w, int n, int c, int n_intervals, const float* out_grad,
+  const int* geom_feats, const int* interval_starts, const int* interval_lengths, float* x_grad);
+
+
+/*
+  Function: pillar pooling (forward, cuda)
+  Args:
+    x                : input features, FloatTensor[n, c]
+    geom_feats       : input coordinates, IntTensor[n, 4]
+    interval_lengths : starting position for pooled point, IntTensor[n_intervals]
+    interval_starts  : how many points in each pooled point, IntTensor[n_intervals]
+  Return:
+    out              : output features, FloatTensor[b, d, h, w, c]
+*/
+at::Tensor bev_pool_forward(
+  const at::Tensor _x,
+  const at::Tensor _geom_feats,
+  const at::Tensor _interval_lengths,
+  const at::Tensor _interval_starts,
+  int b, int d, int h, int w
+) {
+  int n = _x.size(0);
+  int c = _x.size(1);
+  int n_intervals = _interval_lengths.size(0);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(_x));
+  const float* x = _x.data_ptr<float>();
+  const int* geom_feats = _geom_feats.data_ptr<int>();
+  const int* interval_lengths = _interval_lengths.data_ptr<int>();
+  const int* interval_starts = _interval_starts.data_ptr<int>();
+
+  auto options =
+      torch::TensorOptions().dtype(_x.dtype()).device(_x.device());
+  at::Tensor _out = torch::zeros({b, d, h, w, c}, options);
+  float* out = _out.data_ptr<float>();
+  bev_pool(
+    b, d, h, w, n, c, n_intervals, x,
+    geom_feats, interval_starts, interval_lengths, out
+  );
+  return _out;
+}
+
+
+/*
+  Function: pillar pooling (backward, cuda)
+  Args:
+    out_grad         : input features, FloatTensor[b, d, h, w, c]
+    geom_feats       : input coordinates, IntTensor[n, 4]
+    interval_lengths : starting position for pooled point, IntTensor[n_intervals]
+    interval_starts  : how many points in each pooled point, IntTensor[n_intervals]
+  Return:
+    x_grad           : output features, FloatTensor[n, 4]
+*/
+at::Tensor bev_pool_backward(
+  const at::Tensor _out_grad,
+  const at::Tensor _geom_feats,
+  const at::Tensor _interval_lengths,
+  const at::Tensor _interval_starts,
+  int b, int d, int h, int w
+) {
+  int n = _geom_feats.size(0);
+  int c = _out_grad.size(4);
+  int n_intervals = _interval_lengths.size(0);
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(_out_grad));
+  const float* out_grad = _out_grad.data_ptr<float>();
+  const int* geom_feats = _geom_feats.data_ptr<int>();
+  const int* interval_lengths = _interval_lengths.data_ptr<int>();
+  const int* interval_starts = _interval_starts.data_ptr<int>();
+
+  auto options =
+      torch::TensorOptions().dtype(_out_grad.dtype()).device(_out_grad.device());
+  at::Tensor _x_grad = torch::zeros({n, c}, options);
+  float* x_grad = _x_grad.data_ptr<float>();
+
+  bev_pool_grad(
+    b, d, h, w, n, c, n_intervals, out_grad,
+    geom_feats, interval_starts, interval_lengths, x_grad
+  );
+
+  return _x_grad;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("bev_pool_forward", &bev_pool_forward,
+        "bev_pool_forward");
+  m.def("bev_pool_backward", &bev_pool_backward,
+        "bev_pool_backward");
+}

--- a/conch_cuda_ext/ops/vision/bev_pool/bev_pool_kernel.cu
+++ b/conch_cuda_ext/ops/vision/bev_pool/bev_pool_kernel.cu
@@ -1,0 +1,103 @@
+// Copyright 2025 Stack AV Co.
+// SPDX-License-Identifier: Apache-2.0
+
+// https://github.com/mit-han-lab/bevfusion/blob/326653dc06e0938edf1aae7d01efcd158ba83de5/mmdet3d/ops/bev_pool/src/bev_pool_cuda.cu
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+  Function: pillar pooling
+  Args:
+    b                : batch size
+    d                : depth of the feature map
+    h                : height of pooled feature map
+    w                : width of pooled feature map
+    n                : number of input points
+    c                : number of channels
+    n_intervals      : number of unique points
+    x                : input features, FloatTensor[n, c]
+    geom_feats       : input coordinates, IntTensor[n, 4]
+    interval_lengths : starting position for pooled point, IntTensor[n_intervals]
+    interval_starts  : how many points in each pooled point, IntTensor[n_intervals]
+    out              : output features, FloatTensor[b, d, h, w, c]
+*/
+__global__ void bev_pool_kernel(int b, int d, int h, int w, int n, int c, int n_intervals,
+                                  const float *__restrict__ x,
+                                  const int *__restrict__ geom_feats,
+                                  const int *__restrict__ interval_starts,
+                                  const int *__restrict__ interval_lengths,
+                                  float* __restrict__ out) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int index = idx / c;
+  int cur_c = idx % c;
+  if (index >= n_intervals) return;
+  int interval_start = interval_starts[index];
+  int interval_length = interval_lengths[index];
+  const int* cur_geom_feats = geom_feats + interval_start * 4;
+  const float* cur_x = x + interval_start * c + cur_c;
+  float* cur_out = out + cur_geom_feats[3] * d * h * w * c +
+    cur_geom_feats[2] * h * w * c + cur_geom_feats[0] * w * c +
+    cur_geom_feats[1] * c + cur_c;
+  float psum = 0;
+  for(int i = 0; i < interval_length; i++){
+    psum += cur_x[i * c];
+  }
+  *cur_out = psum;
+}
+
+
+/*
+  Function: pillar pooling backward
+  Args:
+    b                : batch size
+    d                : depth of the feature map
+    h                : height of pooled feature map
+    w                : width of pooled feature map
+    n                : number of input points
+    c                : number of channels
+    n_intervals      : number of unique points
+    out_grad         : gradient of the BEV fmap from top, FloatTensor[b, d, h, w, c]
+    geom_feats       : input coordinates, IntTensor[n, 4]
+    interval_lengths : starting position for pooled point, IntTensor[n_intervals]
+    interval_starts  : how many points in each pooled point, IntTensor[n_intervals]
+    x_grad           : gradient of the image fmap, FloatTensor
+*/
+__global__ void bev_pool_grad_kernel(int b, int d, int h, int w, int n, int c, int n_intervals,
+                                  const float *__restrict__ out_grad,
+                                  const int *__restrict__ geom_feats,
+                                  const int *__restrict__ interval_starts,
+                                  const int *__restrict__ interval_lengths,
+                                  float* __restrict__ x_grad) {
+  int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  int index = idx / c;
+  int cur_c = idx % c;
+  if (index >= n_intervals) return;
+  int interval_start = interval_starts[index];
+  int interval_length = interval_lengths[index];
+
+  const int* cur_geom_feats = geom_feats + interval_start * 4;
+  float* cur_x_grad = x_grad + interval_start * c + cur_c;
+
+  const float* cur_out_grad = out_grad + cur_geom_feats[3] * d * h * w * c +
+    cur_geom_feats[2] * h * w * c + cur_geom_feats[0] * w * c +
+    cur_geom_feats[1] * c + cur_c;
+  for(int i = 0; i < interval_length; i++){
+    cur_x_grad[i * c] = *cur_out_grad;
+  }
+
+}
+
+void bev_pool(int b, int d, int h, int w, int n, int c, int n_intervals, const float* x,
+  const int* geom_feats, const int* interval_starts, const int* interval_lengths, float* out) {
+  bev_pool_kernel<<<(int)ceil(((double)n_intervals * c / 256)), 256>>>(
+    b, d, h, w, n, c, n_intervals, x, geom_feats, interval_starts, interval_lengths, out
+  );
+}
+
+void bev_pool_grad(int b, int d, int h, int w, int n, int c, int n_intervals, const float* out_grad,
+  const int* geom_feats, const int* interval_starts, const int* interval_lengths, float* x_grad) {
+  bev_pool_grad_kernel<<<(int)ceil(((double)n_intervals * c / 256)), 256>>>(
+    b, d, h, w, n, c, n_intervals, out_grad, geom_feats, interval_starts, interval_lengths, x_grad
+  );
+}

--- a/conch_cuda_ext/pyproject.toml
+++ b/conch_cuda_ext/pyproject.toml
@@ -1,0 +1,24 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["setuptools>=42", "wheel", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "conch-cuda-ext"
+authors = [
+  { name="Jacob Manning", email="jmanning+oss@stackav.com" },
+  { name="Ryan Hsu", email="rhsu+oss@stackav.com" },
+]
+description = "Conch CUDA Extension"
+requires-python = ">=3.10"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+license = "Apache-2.0"
+
+[project.urls]
+Homepage = "https://github.com/stackav-oss/conch"
+Issues = "https://github.com/stackav-oss/conch/issues"

--- a/conch_cuda_ext/setup.py
+++ b/conch_cuda_ext/setup.py
@@ -1,0 +1,72 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+# Inspired by: https://github.com/mit-han-lab/bevfusion/blob/326653dc06e0938edf1aae7d01efcd158ba83de5/setup.py
+
+import os
+
+import torch
+from setuptools import setup
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+
+
+def make_cuda_ext(
+    name: str,
+    module: str,
+    sources: list[str],
+    sources_cuda: list[str] = [],
+    extra_args: list[str] = [],
+    extra_include_path: list[str] = [],
+) -> CUDAExtension:  # type: ignore[valid-type]
+    define_macros = []
+    extra_compile_args = {"cxx": [] + extra_args}
+
+    if (torch.cuda.is_available() and torch.version.cuda is not None) or os.getenv("FORCE_CUDA", "0") == "1":
+        define_macros += [("WITH_CUDA", None)]
+        extra_compile_args["nvcc"] = extra_args + [
+            "-D__CUDA_NO_HALF_OPERATORS__",
+            "-D__CUDA_NO_HALF_CONVERSIONS__",
+            "-D__CUDA_NO_HALF2_OPERATORS__",
+            "-gencode=arch=compute_80,code=sm_80",
+            "-gencode=arch=compute_86,code=sm_86",
+            "-gencode=arch=compute_90,code=sm_90",
+        ]
+        sources += sources_cuda
+    elif (torch.cuda.is_available() and torch.version.hip is not None) or os.getenv("FORCE_ROCM", "0") == "1":
+        define_macros += [("WITH_ROCM", None)]
+        extra_compile_args["hipcc"] = extra_args + [
+            "-D__HIP_NO_HALF_OPERATORS__",
+            "-D__HIP_NO_HALF_CONVERSIONS__",
+            "-D__HIP_NO_HALF2_OPERATORS__",
+        ]
+        sources += sources_cuda
+
+    return CUDAExtension(  # type: ignore[no-any-return]
+        name="{}.{}".format(module, name),
+        sources=[os.path.join(*module.split("."), p) for p in sources],
+        include_dirs=extra_include_path,
+        define_macros=define_macros,
+        extra_compile_args=extra_compile_args,
+    )
+
+
+setup(
+    name="conch_cuda_ext",
+    classifiers=[
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+    ],
+    license="Apache License 2.0",
+    ext_modules=[
+        make_cuda_ext(
+            name="bev_pool",
+            module="ops.vision.bev_pool",
+            sources=[
+                "bev_pool.cc",
+                "bev_pool_kernel.cu",
+            ],
+        ),
+    ],
+    cmdclass={"build_ext": BuildExtension},
+    zip_safe=False,
+)

--- a/docs/conch/cuda_extension.md
+++ b/docs/conch/cuda_extension.md
@@ -1,0 +1,28 @@
+# CUDA Extension
+
+In some cases, there are not easily-installable external packages that provide a CUDA-accelerated reference implementation for benchmarking/testing.
+For those situations we optionally provide a CUDA extension for Conch.
+
+To build this extension, run the following commands:
+
+```bash
+cd cuda_ext/
+python setup.py develop
+# This should also work:
+# pip install wheel
+# pip install -e . --no-build-isolation
+```
+
+**Note**: After installing the CUDA extension, you may need to reinstall Conch.
+
+```bash
+# Go back to the root of the Conch repo
+cd ..
+pip install -e .
+```
+
+To enable these reference implementations, when applicable, use the following environment variable:
+
+```bash
+CONCH_ENABLE_CUDA_EXT=1
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ follow_untyped_imports = true
 [[tool.mypy.overrides]]
 module = [
   "bitsandbytes.*",
+  "conch_cuda_ext.*",
   "vllm.*",
 ]
 allow_untyped_calls = true

--- a/tests/bev_pool_test.py
+++ b/tests/bev_pool_test.py
@@ -8,9 +8,11 @@ from typing import Final
 import pytest
 import torch
 
-from conch.ops.vision.bev_pool import bev_pool as bev_pool_conch
+from conch.ops.vision.bev_pool import bev_pool as bev_pool_fwd_conch
+from conch.ops.vision.bev_pool import bev_pool_backward as bev_pool_bwd_conch
 from conch.platforms import current_platform
-from conch.reference.vision.bev_pool import bev_pool as bev_pool_ref
+from conch.reference.vision.bev_pool import bev_pool as bev_pool_fwd_ref
+from conch.reference.vision.bev_pool import bev_pool_backward as bev_pool_bwd_ref
 from conch.third_party.vllm.utils import seed_everything
 
 _BATCH_SIZES: Final = [1, 4, 8]
@@ -24,7 +26,7 @@ _GRID_DIMS: Final = [(16, 16, 16), (128, 128, 128)]
 @pytest.mark.parametrize("num_channels", _NUM_CHANNELS)
 @pytest.mark.parametrize("grid_dims", _GRID_DIMS)
 @pytest.mark.parametrize("seed", range(3))
-def test_bev_pool(
+def test_bev_pool_forward(
     batch_size: int, num_points: int, num_channels: int, grid_dims: tuple[int, int, int], seed: int
 ) -> None:
     """Test the bev_pool function."""
@@ -65,7 +67,7 @@ def test_bev_pool(
     geom_feats = geom_feats.int()
 
     # Run the reference implementation
-    output_ref = bev_pool_ref(
+    output_ref = bev_pool_fwd_ref(
         image_feats=image_feats,
         geom_feats=geom_feats,
         interval_starts=interval_starts,
@@ -77,7 +79,7 @@ def test_bev_pool(
     )
 
     # Run the conch implementation
-    output_conch = bev_pool_conch(
+    output_conch = bev_pool_fwd_conch(
         image_feats=image_feats,
         geom_feats=geom_feats,
         interval_starts=interval_starts,
@@ -89,3 +91,74 @@ def test_bev_pool(
     )
 
     torch.testing.assert_close(output_ref, output_conch, atol=1e-5, rtol=1e-5)
+
+
+@pytest.mark.parametrize("batch_size", _BATCH_SIZES)
+@pytest.mark.parametrize("num_points", _NUM_POINTS)
+@pytest.mark.parametrize("num_channels", _NUM_CHANNELS)
+@pytest.mark.parametrize("grid_dims", _GRID_DIMS)
+@pytest.mark.parametrize("seed", range(3))
+def test_bev_pool_backward(
+    batch_size: int, num_points: int, num_channels: int, grid_dims: tuple[int, int, int], seed: int
+) -> None:
+    """Test the bev_pool backward function."""
+    device = current_platform.device
+    torch.set_default_device(device)
+
+    seed_everything(seed)
+
+    grid_cells_z, grid_cells_x, grid_cells_y = grid_dims
+
+    image_feats = torch.randn(num_points, num_channels, device=device, dtype=torch.float32)
+
+    geom_feats_x = torch.randint(low=0, high=grid_cells_x, size=(num_points,), device=device, dtype=torch.long)
+    geom_feats_y = torch.randint(low=0, high=grid_cells_y, size=(num_points,), device=device, dtype=torch.long)
+    geom_feats_z = torch.randint(low=0, high=grid_cells_z, size=(num_points,), device=device, dtype=torch.long)
+    geom_feats_b = torch.randint(low=0, high=batch_size, size=(num_points,), device=device, dtype=torch.long)
+    geom_feats = torch.stack((geom_feats_x, geom_feats_y, geom_feats_z, geom_feats_b), dim=1)
+
+    # Prepare input tensors
+    ranks = (
+        geom_feats[:, 0] * (grid_cells_y * grid_cells_z * batch_size)
+        + geom_feats[:, 1] * (grid_cells_z * batch_size)
+        + geom_feats[:, 2] * batch_size
+        + geom_feats[:, 3]
+    )
+
+    indices = ranks.argsort()
+    image_feats, geom_feats, ranks = image_feats[indices], geom_feats[indices], ranks[indices]
+    image_feats = image_feats.contiguous()
+    geom_feats = geom_feats.contiguous()
+
+    kept = torch.ones(image_feats.shape[0], device=image_feats.device, dtype=torch.bool)
+    kept[1:] = ranks[1:] != ranks[:-1]
+    interval_starts = torch.where(kept)[0].int()
+    interval_lengths = torch.zeros_like(interval_starts)
+    interval_lengths[:-1] = interval_starts[1:] - interval_starts[:-1]
+    interval_lengths[-1] = image_feats.shape[0] - interval_starts[-1]
+    geom_feats = geom_feats.int()
+
+    # Create a gradient tensor for the backward pass
+    grad_output = torch.randn(
+        (batch_size, grid_cells_z, grid_cells_x, grid_cells_y, num_channels),
+        device=device,
+        dtype=torch.float32,
+    )
+
+    # Run the reference backward implementation
+    grad_ref = bev_pool_bwd_ref(
+        grad_output=grad_output,
+        geom_feats=geom_feats,
+        interval_starts=interval_starts,
+        interval_lengths=interval_lengths,
+    )
+
+    # Run the conch backward implementation
+    grad_conch = bev_pool_bwd_conch(
+        grad_output=grad_output,
+        geom_feats=geom_feats,
+        interval_starts=interval_starts,
+        interval_lengths=interval_lengths,
+    )
+
+    torch.testing.assert_close(grad_ref, grad_conch, atol=1e-5, rtol=1e-5)

--- a/tests/bev_pool_test.py
+++ b/tests/bev_pool_test.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Stack AV Co.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test BEV Pool operation."""
+
+from typing import Final
+
+import pytest
+import torch
+
+from conch.ops.vision.bev_pool import bev_pool as bev_pool_conch
+from conch.platforms import current_platform
+from conch.reference.vision.bev_pool import bev_pool as bev_pool_ref
+from conch.third_party.vllm.utils import seed_everything
+
+_BATCH_SIZES: Final = [1, 4, 8]
+_NUM_POINTS: Final = [8, 100, 1000]
+_NUM_CHANNELS: Final = [4, 10]
+_GRID_DIMS: Final = [(16, 16, 16), (128, 128, 128)]
+
+
+@pytest.mark.parametrize("batch_size", _BATCH_SIZES)
+@pytest.mark.parametrize("num_points", _NUM_POINTS)
+@pytest.mark.parametrize("num_channels", _NUM_CHANNELS)
+@pytest.mark.parametrize("grid_dims", _GRID_DIMS)
+@pytest.mark.parametrize("seed", range(3))
+def test_bev_pool(
+    batch_size: int, num_points: int, num_channels: int, grid_dims: tuple[int, int, int], seed: int
+) -> None:
+    """Test the bev_pool function."""
+    device = current_platform.device
+    torch.set_default_device(device)
+
+    seed_everything(seed)
+
+    grid_cells_z, grid_cells_x, grid_cells_y = grid_dims
+
+    image_feats = torch.randn(num_points, num_channels, device=device, dtype=torch.float32)
+
+    geom_feats_x = torch.randint(low=0, high=grid_cells_x, size=(num_points,), device=device, dtype=torch.long)
+    geom_feats_y = torch.randint(low=0, high=grid_cells_y, size=(num_points,), device=device, dtype=torch.long)
+    geom_feats_z = torch.randint(low=0, high=grid_cells_z, size=(num_points,), device=device, dtype=torch.long)
+    geom_feats_b = torch.randint(low=0, high=batch_size, size=(num_points,), device=device, dtype=torch.long)
+    geom_feats = torch.stack((geom_feats_x, geom_feats_y, geom_feats_z, geom_feats_b), dim=1)
+
+    # Prepare input tensors
+    ranks = (
+        geom_feats[:, 0] * (grid_cells_y * grid_cells_z * batch_size)
+        + geom_feats[:, 1] * (grid_cells_z * batch_size)
+        + geom_feats[:, 2] * batch_size
+        + geom_feats[:, 3]
+    )
+
+    indices = ranks.argsort()
+    image_feats, geom_feats, ranks = image_feats[indices], geom_feats[indices], ranks[indices]
+    image_feats = image_feats.contiguous()
+    geom_feats = geom_feats.contiguous()
+
+    kept = torch.ones(image_feats.shape[0], device=image_feats.device, dtype=torch.bool)
+    kept[1:] = ranks[1:] != ranks[:-1]
+    interval_starts = torch.where(kept)[0].int()
+    interval_lengths = torch.zeros_like(interval_starts)
+    interval_lengths[:-1] = interval_starts[1:] - interval_starts[:-1]
+    interval_lengths[-1] = image_feats.shape[0] - interval_starts[-1]
+    geom_feats = geom_feats.int()
+
+    # Run the reference implementation
+    output_ref = bev_pool_ref(
+        image_feats=image_feats,
+        geom_feats=geom_feats,
+        interval_starts=interval_starts,
+        interval_lengths=interval_lengths,
+        batch_size=batch_size,
+        grid_cells_z=grid_cells_z,
+        grid_cells_x=grid_cells_x,
+        grid_cells_y=grid_cells_y,
+    )
+
+    # Run the conch implementation
+    output_conch = bev_pool_conch(
+        image_feats=image_feats,
+        geom_feats=geom_feats,
+        interval_starts=interval_starts,
+        interval_lengths=interval_lengths,
+        batch_size=batch_size,
+        grid_cells_z=grid_cells_z,
+        grid_cells_x=grid_cells_x,
+        grid_cells_y=grid_cells_y,
+    )
+
+    torch.testing.assert_close(output_ref, output_conch, atol=1e-5, rtol=1e-5)

--- a/tests/bev_pool_test.py
+++ b/tests/bev_pool_test.py
@@ -39,10 +39,10 @@ def test_bev_pool_forward(
 
     image_feats = torch.randn(num_points, num_channels, device=device, dtype=torch.float32)
 
-    geom_feats_x = torch.randint(low=0, high=grid_cells_x, size=(num_points,), device=device, dtype=torch.long)
-    geom_feats_y = torch.randint(low=0, high=grid_cells_y, size=(num_points,), device=device, dtype=torch.long)
-    geom_feats_z = torch.randint(low=0, high=grid_cells_z, size=(num_points,), device=device, dtype=torch.long)
-    geom_feats_b = torch.randint(low=0, high=batch_size, size=(num_points,), device=device, dtype=torch.long)
+    geom_feats_x = torch.randint(low=0, high=grid_cells_x, size=(num_points,), device=device, dtype=torch.int32)
+    geom_feats_y = torch.randint(low=0, high=grid_cells_y, size=(num_points,), device=device, dtype=torch.int32)
+    geom_feats_z = torch.randint(low=0, high=grid_cells_z, size=(num_points,), device=device, dtype=torch.int32)
+    geom_feats_b = torch.randint(low=0, high=batch_size, size=(num_points,), device=device, dtype=torch.int32)
     geom_feats = torch.stack((geom_feats_x, geom_feats_y, geom_feats_z, geom_feats_b), dim=1)
 
     # Prepare input tensors
@@ -111,10 +111,10 @@ def test_bev_pool_backward(
 
     image_feats = torch.randn(num_points, num_channels, device=device, dtype=torch.float32)
 
-    geom_feats_x = torch.randint(low=0, high=grid_cells_x, size=(num_points,), device=device, dtype=torch.long)
-    geom_feats_y = torch.randint(low=0, high=grid_cells_y, size=(num_points,), device=device, dtype=torch.long)
-    geom_feats_z = torch.randint(low=0, high=grid_cells_z, size=(num_points,), device=device, dtype=torch.long)
-    geom_feats_b = torch.randint(low=0, high=batch_size, size=(num_points,), device=device, dtype=torch.long)
+    geom_feats_x = torch.randint(low=0, high=grid_cells_x, size=(num_points,), device=device, dtype=torch.int32)
+    geom_feats_y = torch.randint(low=0, high=grid_cells_y, size=(num_points,), device=device, dtype=torch.int32)
+    geom_feats_z = torch.randint(low=0, high=grid_cells_z, size=(num_points,), device=device, dtype=torch.int32)
+    geom_feats_b = torch.randint(low=0, high=batch_size, size=(num_points,), device=device, dtype=torch.int32)
     geom_feats = torch.stack((geom_feats_x, geom_feats_y, geom_feats_z, geom_feats_b), dim=1)
 
     # Prepare input tensors
@@ -151,6 +151,10 @@ def test_bev_pool_backward(
         geom_feats=geom_feats,
         interval_starts=interval_starts,
         interval_lengths=interval_lengths,
+        batch_size=batch_size,
+        grid_cells_z=grid_cells_z,
+        grid_cells_x=grid_cells_x,
+        grid_cells_y=grid_cells_y,
     )
 
     # Run the conch backward implementation


### PR DESCRIPTION
### Description

This PR adds [BEVPool/QuickCumSum](https://github.com/mit-han-lab/bevfusion/blob/326653dc06e0938edf1aae7d01efcd158ba83de5/mmdet3d/ops/bev_pool/src/bev_pool_cuda.cu) from [BEVFusion](https://github.com/mit-han-lab/bevfusion) to Conch.

We provide a pure PyTorch implementation, Triton kernel, and an optionally-compiled CUDA kernel  for both the forward and backward pass of this operation. There is also a unit test and microbenchmark for both the fwd and bwd pass.

### Testing

Please select all that apply.

- [ ] Existing unit tests
- [x] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```bash
# Add CONCH_ENABLE_CUDA_EXT=1 to compare against CUDA instead of PyTorch
pytest tests/bev_pool_test.py
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [x] AMD GPU
- [ ] Other (please explain)

**Note**: we are getting correctness issues with the HIP-ified CUDA kernel on AMD MI300X. The test will fail with the CUDA extension, but passes against the PyTorch ref impl.

### Benchmarks

_Forward_

```bash
CONCH_ENABLE_CUDA_EXT=1 python benchmarks/bev_pool_benchmark.py
# -Or-
python benchmarks/bev_pool_benchmark.py --compile-ref --cuda-ref
```

_Backward_

```bash
CONCH_ENABLE_CUDA_EXT=1 python benchmarks/bev_pool_benchmark.py
# Could run this but PyTorch/compiled version are _super_ slow
# python benchmarks/bev_pool_backward_benchmark.py --compile-ref --cuda-ref
```

**A10**

_Forward_

```bash
# Omitted PyTorch reference + compiled because its slow (see H100/MI300X numbers below)
Number of intervals: 4790425
Min interval length: 1.0
Mean interval length: 1.2524983882904053
Max interval length: 7.0
Reference vs Conch: Results matched with atol=0.001 :)
Parameters: {'num_points': 6000000, 'num_channels': 64, 'batch_size': 1, 'grid_cells_z': 20, 'grid_cells_x': 800, 'grid_cells_y': 800}
Conch: num_iterations=755, min=12.668 ms, max=12.791 ms, mean=12.696 ms, median=12.697 ms
Baseline: num_iterations=636, min=15.142 ms, max=15.248 ms, mean=15.150 ms, median=15.149 ms
```

_Backward_

```bash
# Omitted PyTorch reference + compiled because its slow (see H100/MI300X numbers below)
Reference vs Conch: Results matched with atol=0.001 :)
Parameters: {'num_points': 6000000, 'num_channels': 64, 'batch_size': 1, 'grid_cells_z': 20, 'grid_cells_x': 800, 'grid_cells_y': 800}
Conch: num_iterations=1026, min=9.180 ms, max=9.213 ms, mean=9.195 ms, median=9.194 ms
Baseline: num_iterations=816, min=11.688 ms, max=11.703 ms, mean=11.694 ms, median=11.694 ms
```

**H100**

_Forward_

```bash
Number of intervals: 4789543
Min interval length: 1.0
Mean interval length: 1.2527291774749756
Max interval length: 8.0
Reference vs Conch: Results matched with atol=0.001 :)
Parameters: {'num_points': 6000000, 'num_channels': 64, 'batch_size': 1, 'grid_cells_z': 20, 'grid_cells_x': 800, 'grid_cells_y': 800}
Conch: num_iterations=3790, min=2.548 ms, max=2.566 ms, mean=2.551 ms, median=2.551 ms
Baseline: num_iterations=1, min=691031.875 ms, max=691031.875 ms, mean=691031.875 ms, median=691031.875 ms
Reference (Compiled): num_iterations=1, min=691136.375 ms, max=691136.375 ms, mean=691136.375 ms, median=691136.375 ms
CUDA: num_iterations=2876, min=3.384 ms, max=3.399 ms, mean=3.387 ms, median=3.387 ms
```

_Backward_

```bash
# Omitted PyTorch reference + compiled because its slow (see above)
Reference vs Conch: Results matched with atol=0.001 :)
Parameters: {'num_points': 6000000, 'num_channels': 64, 'batch_size': 1, 'grid_cells_z': 20, 'grid_cells_x': 800, 'grid_cells_y': 800}
Conch: num_iterations=6518, min=1.445 ms, max=1.458 ms, mean=1.448 ms, median=1.447 ms
Baseline: num_iterations=3240, min=2.991 ms, max=3.003 ms, mean=2.994 ms, median=2.994 ms
```

**MI300X**

_Forward_

```bash
Number of intervals: 4789796
Min interval length: 1.0
Mean interval length: 1.2526628971099854
Max interval length: 7.0
Reference vs Conch: Results matched with atol=0.001 :)
Parameters: {'num_points': 6000000, 'num_channels': 64, 'batch_size': 1, 'grid_cells_z': 20, 'grid_cells_x': 800, 'grid_cells_y': 800}
Conch: num_iterations=6740, min=1.410 ms, max=1.459 ms, mean=1.431 ms, median=1.431 ms
Baseline: num_iterations=1, min=860818.938 ms, max=860818.938 ms, mean=860818.938 ms, median=860818.938 ms
Reference (Compiled): num_iterations=1, min=875389.500 ms, max=875389.500 ms, mean=875389.500 ms, median=875389.500 ms
CUDA: num_iterations=14138, min=0.635 ms, max=0.686 ms, mean=0.648 ms, median=0.647 ms
```

_Backward_

```bash
# Omitted PyTorch reference + compiled because its slow (see above)
# Note: HIP-ified CUDA impl appears to be giving incorrect answers...
WARNING: Reference and Conch results differ! (atol=0.001)
Output max diff: 6.037900924682617
Ref shape: torch.Size([6000000, 64]), Conch shape: torch.Size([6000000, 64])
Parameters: {'num_points': 6000000, 'num_channels': 64, 'batch_size': 1, 'grid_cells_z': 20, 'grid_cells_x': 800, 'grid_cells_y': 800}
Conch: num_iterations=8597, min=1.101 ms, max=1.139 ms, mean=1.116 ms, median=1.115 ms
Baseline: num_iterations=19586, min=0.298 ms, max=0.326 ms, mean=0.305 ms, median=0.304 ms
```