### PR TITLE
Cleanup voxelization

### DIFF
--- a/conch/kernels/vision/voxelization.py
+++ b/conch/kernels/vision/voxelization.py
@@ -8,8 +8,8 @@ import triton
 import triton.language as tl
 
 
-@triton.jit
-def generate_dense_voxels_triton_kernel(  # noqa: PLR0913, D417
+@triton.jit  # type: ignore[misc]
+def generate_dense_voxels_triton_kernel(
     # input
     points_ptr: torch.Tensor,
     num_points: int,
@@ -73,8 +73,8 @@ def generate_dense_voxels_triton_kernel(  # noqa: PLR0913, D417
     tl.store(dense_point_features_ptr + output_idx * 4 + 3, point_w, mask=output_mask)
 
 
-@triton.jit
-def generate_voxels_triton_kernel(  # noqa: PLR0913, D417
+@triton.jit  # type: ignore[misc]
+def generate_voxels_triton_kernel(
     # input
     dense_point_features_ptr: torch.Tensor,
     dense_num_points_per_voxel_ptr: torch.Tensor,

--- a/conch/ops/vision/voxelization.py
+++ b/conch/ops/vision/voxelization.py
@@ -61,10 +61,9 @@ def generate_voxels(
             empty points are filled with 0.
             voxel_indices, shape [num_filled_voxels, 4], only first 3 fields are used for x,y,z indices.
     """
-    assert points.is_cuda
     device = points.device
     num_points, num_features_per_point = points.shape
-    assert num_features_per_point == 4  # noqa: PLR2004
+    assert num_features_per_point == 4
     # same as original nvidia cuda impl
     num_elements_per_voxel_index = 4
 
@@ -105,7 +104,7 @@ def generate_voxels(
         dense_num_points_per_voxel,
         dense_point_features,
         cxpr_block_size=block_size,
-        num_warps=block_size // num_threads_per_warp,  # pyright: ignore[reportCallIssue]
+        num_warps=block_size // num_threads_per_warp,
     )
 
     # compress into contiguous/sparse filled voxels
@@ -122,7 +121,7 @@ def generate_voxels(
         point_features,
         voxel_indices,
         cxpr_block_size=block_size,
-        num_warps=block_size // num_threads_per_warp,  # pyright: ignore[reportCallIssue]
+        num_warps=block_size // num_threads_per_warp,
     )
 
     total_filled_voxels = num_filled_voxels.cpu()[0]


### PR DESCRIPTION
### Description

This PR does some misc cleanup on the voxelization code. Pre-commit checks now pass, we have a fixed seed for testing/benchmarking, removed platform-specific assumptions, and added more parameterized test cases.

### Testing

Please select all that apply.

- [x] Existing unit tests
- [x] Unit tests added by this PR
- [ ] Other (please explain)
- [ ] This PR is not tested

#### Test instructions

```
pytest tests/voxelization_test.py
```

```
CONCH_ENABLE_CUDA_EXT=1 python benchmarks/voxelization_benchmark.py --cuda-ref
```

**A10**

```
32 passed in 74.27s (0:01:14)
```

```
Number of points: 500000
Grid dimensions: (40, 40, 40)
Max number of voxels: 64000
Max number of points per voxel: 4
voxelization done, stats:
number of points within grid boundary: 159073
number of filled voxels: 57510
Avg number of points per voxel: 2.766005754470825
Max number of points per voxel: 14
Number of voxels with overflowing points: 7818
Parameters: {'num_points': 500000, 'max_num_points_per_voxel': 4, 'voxel_dim': 2.5, 'grid_range': 50.0}
Conch: num_iterations=137, min=0.172 ms, max=0.256 ms, mean=0.188 ms, median=0.185 ms
Baseline: num_iterations=37, min=0.630 ms, max=1.012 ms, mean=0.809 ms, median=0.845 ms
CUDA: num_iterations=152, min=0.105 ms, max=0.133 ms, mean=0.116 ms, median=0.116 ms
```

**H100**

```
32 passed in 44.82s
```

```
Number of points: 500000
Grid dimensions: (40, 40, 40)
Max number of voxels: 64000
Max number of points per voxel: 4
voxelization done, stats:
number of points within grid boundary: 159079
number of filled voxels: 57542
Avg number of points per voxel: 2.7645719051361084
Max number of points per voxel: 13
Number of voxels with overflowing points: 7814
Parameters: {'num_points': 500000, 'max_num_points_per_voxel': 4, 'voxel_dim': 2.5, 'grid_range': 50.0}
Conch: num_iterations=462, min=0.096 ms, max=0.145 ms, mean=0.103 ms, median=0.101 ms
Baseline: num_iterations=74, min=0.308 ms, max=0.356 ms, mean=0.321 ms, median=0.319 ms
CUDA: num_iterations=757, min=0.046 ms, max=0.056 ms, mean=0.050 ms, median=0.050 ms
```

**MI300X**

```
32 passed in 57.26s
```

```
Number of points: 500000
Grid dimensions: (40, 40, 40)
Max number of voxels: 64000
Max number of points per voxel: 4
voxelization done, stats:
number of points within grid boundary: 159209
number of filled voxels: 57609
Avg number of points per voxel: 2.76361346244812
Max number of points per voxel: 13
Number of voxels with overflowing points: 7924
Parameters: {'num_points': 500000, 'max_num_points_per_voxel': 4, 'voxel_dim': 2.5, 'grid_range': 50.0}
Conch: num_iterations=243, min=0.324 ms, max=0.353 ms, mean=0.334 ms, median=0.334 ms
Baseline: num_iterations=80, min=0.415 ms, max=0.448 ms, mean=0.428 ms, median=0.428 ms
CUDA: num_iterations=1210, min=0.039 ms, max=0.170 ms, mean=0.044 ms, median=0.044 ms
```

#### Platforms

Please select all hardware platforms that this PR was tested on.

- [x] Nvidia GPU
- [x] AMD GPU
- [ ] Other (please explain)
